### PR TITLE
Introduce a fairness supervisor

### DIFF
--- a/packages/kate-core/source/os/ipc/browser.ts
+++ b/packages/kate-core/source/os/ipc/browser.ts
@@ -1,24 +1,23 @@
-import { EMessageFailed, handler } from "./handlers";
+import { EMessageFailed, auth_handler, handler } from "./handlers";
 import { TC } from "../../utils";
 
 export default [
-  handler(
+  auth_handler(
     "kate:browser.open",
     TC.spec({ url: TC.url }),
+    {
+      fail_silently: true,
+      capabilities: [{ type: "open-urls" }],
+    },
     async (os, env, ipc, { url }) => {
-      if (
-        !(await os.capability_supervisor.is_allowed(env.cart.id, "open-urls", {
-          url,
-        }))
-      ) {
-        console.error(
-          `Blocked ${env.cart.id} from opening ${url}: capability not granted`
-        );
-        return null;
-      }
-
       try {
-        await os.browser.open(env.cart.id, url);
+        await os.fairness_supervisor.with_resource(
+          env.cart.id,
+          "modal-dialog",
+          async () => {
+            await os.browser.open(env.cart.id, url);
+          }
+        );
       } catch (error) {
         console.error(
           `Failed to open ${url} at the request of ${env.cart.id}:`,
@@ -30,25 +29,22 @@ export default [
     }
   ),
 
-  handler(
+  auth_handler(
     "kate:browser.download",
     TC.spec({ filename: TC.short_str(255), data: TC.bytearray }),
+    {
+      fail_silently: true,
+      capabilities: [{ type: "download-files" }],
+    },
     async (os, env, ipc, { filename, data }) => {
-      if (
-        !(await os.capability_supervisor.is_allowed(
-          env.cart.id,
-          "download-files",
-          {}
-        ))
-      ) {
-        console.error(
-          `Blocked ${env.cart.id} from downloading ${filename}: capability not granted`
-        );
-        return null;
-      }
-
       try {
-        await os.browser.download(env.cart.id, filename, data);
+        await os.fairness_supervisor.with_resource(
+          env.cart.id,
+          "modal-dialog",
+          async () => {
+            await os.browser.download(env.cart.id, filename, data);
+          }
+        );
       } catch (error) {
         console.error(
           `Failed to download ${filename} at the request of ${env.cart.id}:`,

--- a/packages/kate-core/source/os/ipc/cart_manager.ts
+++ b/packages/kate-core/source/os/ipc/cart_manager.ts
@@ -1,51 +1,45 @@
 import { TC } from "../../utils";
-import { EMessageFailed, handler } from "./handlers";
+import { EMessageFailed, auth_handler, handler } from "./handlers";
 import * as Cart from "../../cart";
 import * as UI from "../ui";
 
 export default [
-  handler(
+  auth_handler(
     "kate:cart-manager.install",
     TC.spec({ cartridge: TC.bytearray }),
+    { capabilities: [{ type: "install-cartridges" }] },
     async (os, env, ipc, { cartridge }) => {
-      const cart = Cart.parse(cartridge);
-      const errors = await Cart.verify_integrity(cart);
-      if (errors.length !== 0) {
-        console.error(`Corrupted cartridge ${cart.id}`, errors);
-        throw new EMessageFailed(
-          "kate.cart-manager.corrupted",
-          `Corrupted cartridge`
-        );
-      }
+      return await os.fairness_supervisor.with_resource(
+        env.cart.id,
+        "modal-dialog",
+        async () => {
+          const cart = Cart.parse(cartridge);
+          const errors = await Cart.verify_integrity(cart);
+          if (errors.length !== 0) {
+            console.error(`Corrupted cartridge ${cart.id}`, errors);
+            throw new EMessageFailed(
+              "kate.cart-manager.corrupted",
+              `Corrupted cartridge`
+            );
+          }
 
-      if (
-        !(await os.capability_supervisor.is_allowed(
-          env.cart.id,
-          "install-cartridges",
-          { id: cart.id }
-        ))
-      ) {
-        console.error(
-          `Blocked ${env.cart.id} from installing a cartridge: capability not granted`
-        );
-        throw new EMessageFailed("kate.cart-manager.no-access", "No access");
-      }
-
-      const should_install = await os.dialog.confirm("kate:cart-manager", {
-        title: "Install cartridge?",
-        message: UI.stack([
-          UI.paragraph([
-            UI.strong([UI.mono_text([env.cart.id])]),
-            " wants to install a cartridge:",
-            UI.cartridge_chip(cart),
-          ]),
-        ]),
-      });
-      if (!should_install) {
-        return null;
-      }
-      await os.cart_manager.install(cart);
-      return null;
+          const should_install = await os.dialog.confirm("kate:cart-manager", {
+            title: "Install cartridge?",
+            message: UI.stack([
+              UI.paragraph([
+                UI.strong([UI.mono_text([env.cart.id])]),
+                " wants to install a cartridge:",
+                UI.cartridge_chip(cart),
+              ]),
+            ]),
+          });
+          if (!should_install) {
+            return null;
+          }
+          await os.cart_manager.install(cart);
+          return null;
+        }
+      );
     }
   ),
 ];

--- a/packages/kate-core/source/os/os.ts
+++ b/packages/kate-core/source/os/os.ts
@@ -28,6 +28,7 @@ import { KateBrowser } from "./apis/browse";
 import { KateCapabilitySupervisor } from "./services/capability-supervisor";
 import { KateAuditSupervisor } from "./services/audit-supervisor";
 import { KateDeviceFile } from "./apis/device-file";
+import { KateFairnessSupervisor } from "./services/fairness-supervisor";
 
 export type CartChangeReason =
   | "installed"
@@ -55,8 +56,11 @@ export class KateOS {
   readonly app_resources: KateAppResources;
   readonly browser: KateBrowser;
   readonly device_file: KateDeviceFile;
+  // Services
   readonly capability_supervisor: KateCapabilitySupervisor;
   readonly audit_supervisor: KateAuditSupervisor;
+  readonly fairness_supervisor: KateFairnessSupervisor;
+
   readonly events = {
     on_cart_inserted: new EventStream<Cart.CartMeta>(),
     on_cart_removed: new EventStream<{ id: string; title: string }>(),
@@ -98,6 +102,7 @@ export class KateOS {
     this.device_file = new KateDeviceFile(this);
     this.capability_supervisor = new KateCapabilitySupervisor(this);
     this.audit_supervisor = new KateAuditSupervisor(this);
+    this.fairness_supervisor = new KateFairnessSupervisor(this);
   }
 
   get display() {

--- a/packages/kate-core/source/os/services/fairness-supervisor.ts
+++ b/packages/kate-core/source/os/services/fairness-supervisor.ts
@@ -1,0 +1,96 @@
+import { Deferred, unreachable } from "../../utils";
+import type { KateOS } from "../os";
+
+type Resource = "modal-dialog";
+type ProcessId = string;
+
+class FairLock {
+  constructor(readonly resource: Resource, readonly process_id: string) {}
+}
+
+export class KateFairnessSupervisor {
+  private _resources = new Map<ProcessId, Map<Resource, Set<FairLock>>>();
+  constructor(readonly os: KateOS) {}
+
+  private get_locks(process_id: ProcessId, resource: Resource): Set<FairLock> {
+    const resources =
+      this._resources.get(process_id) ?? new Map<Resource, Set<FairLock>>();
+    return resources.get(resource) ?? new Set<FairLock>();
+  }
+
+  private update_resources(
+    process_id: ProcessId,
+    resource: Resource,
+    fn: (_: Set<FairLock>) => void
+  ) {
+    if (!this._resources.has(process_id)) {
+      this._resources.set(process_id, new Map());
+    }
+    const resources = this._resources.get(process_id)!;
+    if (!resources.has(resource)) {
+      resources.set(resource, new Set());
+    }
+    const locks = resources.get(resource)!;
+    fn(locks);
+  }
+
+  async take(process_id: ProcessId, resource: Resource) {
+    if (this.is_allowed(process_id, resource)) {
+      console.debug(
+        `[kate:fairness] ${process_id} acquired a lock for ${resource}`
+      );
+      const lock = new FairLock(resource, process_id);
+      this.update_resources(process_id, resource, (locks) => {
+        locks.add(lock);
+      });
+      return lock;
+    } else {
+      console.error(
+        `[kate:fairness] ${process_id} failed to acquire a lock for ${resource}`
+      );
+      return null;
+    }
+  }
+
+  release(lock: FairLock) {
+    const locks = this.get_locks(lock.process_id, lock.resource);
+    locks.delete(lock);
+    console.debug(
+      `[kate:fairness] ${lock.process_id} released a lock for ${lock.resource}`
+    );
+  }
+
+  async with_resource<A>(
+    process_id: ProcessId,
+    resource: Resource,
+    action: () => Promise<A>,
+    on_failed: () => Error = () =>
+      new Error(`Failed to take a lock to ${resource} for ${process_id}`)
+  ) {
+    const lock = await this.take(process_id, resource);
+    if (lock == null) {
+      throw on_failed();
+    }
+
+    try {
+      const result = await action();
+      return result;
+    } finally {
+      this.release(lock);
+    }
+  }
+
+  private is_allowed(process_id: ProcessId, resource: Resource) {
+    switch (resource) {
+      case "modal-dialog": {
+        return (
+          this.os.processes.is_foreground(process_id) &&
+          this.get_locks(process_id, resource).size === 0
+        );
+      }
+
+      default:
+        throw unreachable(resource);
+    }
+  }
+}


### PR DESCRIPTION
This patch introduces a "fairness supervisor". Right now this is pretty straight-forward, and just checks that a cartridge is not abusing modal dialogs to prevent users from using the device (since modal dialogs always stack on top of the current foreground screen). This means that from now on cartridges will only be able to show a modal dialog if they are the screen on foreground and if they are not showing another modal dialog (it shouldn't be possible with the first restriction in any case).

There may be more fairness quotas applied later, particularly once Kate supports multiple processes, as there we'd like to ensure that no cartridge hogs the entire device to itself.