### PR TITLE
Support mapping new buttons

### DIFF
--- a/packages/kate-core/source/os/apps/settings/gamepad-input.ts
+++ b/packages/kate-core/source/os/apps/settings/gamepad-input.ts
@@ -816,11 +816,13 @@ export class RemapStandardSettings extends UI.SimpleScene {
                 choose_pressed("down", "Down"),
                 choose_pressed("left", "Left"),
                 choose_pressed("o", "Ok"),
+                choose_pressed("sparkle", "Sparkle"),
                 choose_pressed("x", "Cancel"),
                 choose_pressed("ltrigger", "L"),
                 choose_pressed("rtrigger", "R"),
                 choose_pressed("menu", "Menu"),
                 choose_pressed("capture", "Capture"),
+                choose_pressed("berry", "Berry"),
                 choose_pressed(null, "None"),
               ]);
             })

--- a/www/css/os/screens/gamepad-mapping.css
+++ b/www/css/os/screens/gamepad-mapping.css
@@ -93,6 +93,13 @@
   align-items: center;
   gap: 0.5rem;
   margin-top: 1rem;
+  overflow: scroll;
+  padding: 0.5rem;
+  scrollbar-width: none;
+}
+
+.gamepad-remap-kate-buttons::-webkit-scrollbar {
+  height: 0;
 }
 
 .kate-key-button {

--- a/www/css/os/screens/home.css
+++ b/www/css/os/screens/home.css
@@ -13,7 +13,7 @@
 }
 
 .kate-os-carts-scroll {
-  overflow: hidden;
+  overflow-x: scroll;
   padding: 5px 0;
   scroll-behavior: smooth;
   scroll-padding: 30px;
@@ -22,7 +22,13 @@
   background-position-x: 560px;
   background-position-y: 150px;
   flex-grow: 1;
+  scrollbar-width: none;
 }
+
+.kate-os-carts-scroll::-webkit-scrollbar {
+  height: 0;
+}
+
 
 .kate-os-carts {
   margin: 15px;


### PR DESCRIPTION
Missed allowing the new buttons in the gamepad configuration screen. This patch fixes that.