### PR TITLE
Principled trusted mode

### DIFF
--- a/packages/kate-core/source/kernel/kate.ts
+++ b/packages/kate-core/source/kernel/kate.ts
@@ -36,13 +36,8 @@ export class KateKernel {
     return new KateKernel(console);
   }
 
-  enter_trusted_mode() {
-    this.console.body!.classList.add("trusted-mode");
-    this.console.resources.take("trusted-mode");
-  }
-
-  exit_trusted_mode() {
-    this.console.body!.classList.remove("trusted-mode");
-    this.console.resources.release("trusted-mode");
+  set_running_process(application_id: string, trusted: boolean) {
+    this.console.body!.classList.toggle("trusted-mode", trusted);
+    this.console.resources.set_running_process({ application_id, trusted });
   }
 }

--- a/packages/kate-core/source/kernel/resource.ts
+++ b/packages/kate-core/source/kernel/resource.ts
@@ -4,15 +4,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export type Resource = "screen-recording" | "transient-storage" | "low-storage" | "trusted-mode";
+export type Resource = "screen-recording" | "transient-storage" | "low-storage";
+export type RunningProcessMeta = {
+  application_id: string;
+  trusted: boolean;
+};
 
 export class KateResources {
   readonly resources = new Map<Resource, number>();
+  private running_process: RunningProcessMeta | null = null;
 
   constructor(private _root: HTMLElement) {
     if (_root == null) {
       throw new Error(`[kernel:resources] invalid HTML tree`);
     }
+  }
+
+  set_running_process(process: RunningProcessMeta | null) {
+    console.debug(
+      `[kernel:resource] changed running process to ${process?.application_id ?? null} (trusted: ${
+        process?.trusted ?? null
+      })`
+    );
+    this.running_process = process;
+    this.update_display();
   }
 
   take(resource: Resource) {
@@ -45,6 +60,13 @@ export class KateResources {
         e.className = `kate-resource kate-resource-${resource}`;
         this._root.append(e);
       }
+    }
+    if (this.running_process != null) {
+      const e = document.createElement("div");
+      e.className = "kate-resource kate-current-process-indicator";
+      e.title = this.running_process.application_id;
+      e.toggleAttribute("data-trusted", this.running_process.trusted);
+      this._root.append(e);
     }
   }
 }

--- a/packages/kate-core/source/os/apis/context_menu.ts
+++ b/packages/kate-core/source/os/apis/context_menu.ts
@@ -73,6 +73,8 @@ export class KateContextMenu {
 }
 
 export class HUD_ContextMenu extends Scene {
+  readonly application_id = "kate:context-menu";
+
   readonly on_close = new EventStream<void>();
 
   constructor(readonly os: KateOS, readonly context: KateContextMenu) {

--- a/packages/kate-core/source/os/apis/dialog.ts
+++ b/packages/kate-core/source/os/apis/dialog.ts
@@ -15,7 +15,7 @@ export class KateDialog {
   constructor(readonly os: KateOS) {}
 
   async message(id: string, x: { title: string; message: UI.Widgetable }) {
-    const hud = new HUD_Dialog(this, "message");
+    const hud = new HUD_Dialog(this, "message", id);
     try {
       this.os.push_scene(hud);
       return await hud.show(
@@ -40,7 +40,7 @@ export class KateDialog {
       dangerous?: boolean;
     }
   ) {
-    const hud = new HUD_Dialog(this, "confirm");
+    const hud = new HUD_Dialog(this, "confirm", id);
     try {
       this.os.push_scene(hud);
       return await hud.show(
@@ -63,7 +63,7 @@ export class KateDialog {
   }
 
   async progress(id: string, message: UI.Widgetable, process: (_: Progress) => Promise<void>) {
-    const hud = new HUD_Dialog(this, "progress");
+    const hud = new HUD_Dialog(this, "progress", id);
     try {
       this.os.push_scene(hud);
       return await hud.progress(id, message, process);
@@ -161,7 +161,7 @@ export class KateDialog {
     cancel_value: A,
     description: string = "custom"
   ): Deferred<A> {
-    const hud = new HUD_Dialog(this, description);
+    const hud = new HUD_Dialog(this, description, id);
     this.os.push_scene(hud);
     const deferred = hud.custom(id, `kate-hud-dialog-custom ${className}`, contents, cancel_value);
     deferred.promise.finally(() => {
@@ -176,7 +176,7 @@ export class KateDialog {
     buttons: { label: string; value: A }[],
     cancel_value: A
   ) {
-    const hud = new HUD_Dialog(this, "pop-menu");
+    const hud = new HUD_Dialog(this, "pop-menu", id);
     try {
       this.os.push_scene(hud);
       return await hud.pop_menu(id, heading, buttons, cancel_value);
@@ -211,7 +211,11 @@ export class Progress {
 export class HUD_Dialog extends Scene {
   readonly FADE_OUT_TIME_MS = 250;
 
-  constructor(readonly manager: KateDialog, readonly description = "dialog") {
+  constructor(
+    readonly manager: KateDialog,
+    readonly description = "dialog",
+    readonly application_id: string
+  ) {
     super(manager.os, false);
     (this as any).canvas = UI.h("div", { class: "kate-hud-dialog", "data-title": description }, []);
   }
@@ -220,20 +224,9 @@ export class HUD_Dialog extends Scene {
     return null;
   }
 
-  is_trusted(id: string) {
-    return id.startsWith("kate:");
-  }
-
   async progress(id: string, message: UI.Widgetable, process: (_: Progress) => Promise<void>) {
     const progress = new Progress(message);
-    const element = UI.h(
-      "div",
-      {
-        class: "kate-hud-dialog-message",
-        "data-trusted": String(this.is_trusted(id)),
-      },
-      [progress.canvas]
-    );
+    const element = UI.h("div", { class: "kate-hud-dialog-message" }, [progress.canvas]);
     try {
       const result = process(progress);
       this.canvas.textContent = "";
@@ -287,45 +280,32 @@ export class HUD_Dialog extends Scene {
 
   custom<A>(id: string, className: string, content: UI.Widgetable[], cancel_value: A) {
     const result = defer<A>();
-    const dialog = UI.h(
-      "div",
-      {
-        class: `kate-hud-dialog-root ${className}`,
-        "data-trusted": String(this.is_trusted(id)),
-      },
-      [UI.h("div", { class: "kate-hud-dialog-container" }, [...content])]
-    );
+    const dialog = UI.h("div", { class: `kate-hud-dialog-root ${className}` }, [
+      UI.h("div", { class: "kate-hud-dialog-container" }, [...content]),
+    ]);
     dialog.addEventListener("click", (ev) => {
       if (ev.target === dialog) {
         result.resolve(cancel_value);
       }
     });
-    if (this.is_trusted(id)) {
-      this.os.kernel.enter_trusted_mode();
-    }
-    try {
-      this.canvas.textContent = "";
-      this.canvas.appendChild(dialog);
-      const key_handler = (x: { key: KateButton; is_repeat: boolean }) => {
-        if (x.key === "x" && !x.is_repeat) {
-          result.resolve(cancel_value);
-          return true;
-        }
-        return false;
-      };
-      this.os.focus_handler.listen(this.canvas, key_handler);
-      result.promise.finally(() => {
-        this.os.kernel.exit_trusted_mode();
-        this.os.focus_handler.remove(this.canvas, key_handler);
-        setTimeout(async () => {
-          dialog.classList.add("leaving");
-          await wait(this.FADE_OUT_TIME_MS);
-          dialog.remove();
-        });
+    this.canvas.textContent = "";
+    this.canvas.appendChild(dialog);
+    const key_handler = (x: { key: KateButton; is_repeat: boolean }) => {
+      if (x.key === "x" && !x.is_repeat) {
+        result.resolve(cancel_value);
+        return true;
+      }
+      return false;
+    };
+    this.os.focus_handler.listen(this.canvas, key_handler);
+    result.promise.finally(() => {
+      this.os.focus_handler.remove(this.canvas, key_handler);
+      setTimeout(async () => {
+        dialog.classList.add("leaving");
+        await wait(this.FADE_OUT_TIME_MS);
+        dialog.remove();
       });
-    } catch (_) {
-      this.os.kernel.exit_trusted_mode();
-    }
+    });
     return result;
   }
 

--- a/packages/kate-core/source/os/apis/drop-installer.ts
+++ b/packages/kate-core/source/os/apis/drop-installer.ts
@@ -36,6 +36,8 @@ export class KateDropInstaller {
 }
 
 export class HUD_DropInstaller extends Scene {
+  readonly application_id = "kate:drop-installer";
+
   constructor(readonly manager: KateDropInstaller) {
     super(manager.os, true);
     (this as any).canvas = UI.h("div", { class: "kate-hud-drop-installer" }, []);

--- a/packages/kate-core/source/os/apis/notification.ts
+++ b/packages/kate-core/source/os/apis/notification.ts
@@ -26,27 +26,18 @@ export class KateNotification {
     this.hud.show(title, message);
   }
 
-  async log(
-    process_id: string,
-    title: string,
-    message: string,
-    allow_failures: boolean = false
-  ) {
+  async log(process_id: string, title: string, message: string, allow_failures: boolean = false) {
     try {
-      await this.os.db.transaction(
-        [Db.notifications],
-        "readwrite",
-        async (t) => {
-          const notifications = t.get_table1(Db.notifications);
-          await notifications.put({
-            type: "basic",
-            process_id,
-            time: new Date(),
-            title,
-            message,
-          });
-        }
-      );
+      await this.os.db.transaction([Db.notifications], "readwrite", async (t) => {
+        const notifications = t.get_table1(Db.notifications);
+        await notifications.put({
+          type: "basic",
+          process_id,
+          time: new Date(),
+          title,
+          message,
+        });
+      });
     } catch (error) {
       console.error(`[Kate] failed to store audit log:`, error, {
         process_id,
@@ -65,6 +56,8 @@ export class KateNotification {
 }
 
 export class HUD_Toaster extends Scene {
+  readonly application_id = "kate:notifications";
+
   readonly NOTIFICATION_WAIT_TIME_MS = 5000;
   readonly FADE_OUT_TIME_MS = 250;
 

--- a/packages/kate-core/source/os/apis/status-bar.ts
+++ b/packages/kate-core/source/os/apis/status-bar.ts
@@ -24,6 +24,8 @@ export class KateStatusBar {
 }
 
 export class HUD_StatusBar extends Scene {
+  readonly application_id = "kate:status-bar";
+
   private _timer: any = null;
   readonly STATUS_LINE_TIME_MS = 5000;
 
@@ -37,19 +39,14 @@ export class HUD_StatusBar extends Scene {
   }
 
   show(content: Widgetable) {
-    const status = new KateStatus(
-      this,
-      h("div", { class: "kate-hud-status-item" }, [content])
-    );
+    const status = new KateStatus(this, h("div", { class: "kate-hud-status-item" }, [content]));
     this.canvas.appendChild(status.canvas);
     this.tick();
     return status;
   }
 
   refresh() {
-    const items = Array.from(
-      this.canvas.querySelectorAll(".kate-hud-status-item")
-    );
+    const items = Array.from(this.canvas.querySelectorAll(".kate-hud-status-item"));
     if (items.length === 0) {
       this.canvas.classList.remove("active");
     } else {
@@ -59,9 +56,7 @@ export class HUD_StatusBar extends Scene {
 
   private tick() {
     clearTimeout(this._timer);
-    const items = Array.from(
-      this.canvas.querySelectorAll(".kate-hud-status-item")
-    );
+    const items = Array.from(this.canvas.querySelectorAll(".kate-hud-status-item"));
     if (items.length > 0) {
       this.canvas.classList.add("active");
       const current = items.findIndex((x) => x.classList.contains("active"));

--- a/packages/kate-core/source/os/apps/about-kate.ts
+++ b/packages/kate-core/source/os/apps/about-kate.ts
@@ -39,6 +39,7 @@ export function bool_text(x: boolean | null) {
 export class SceneAboutKate extends SimpleScene {
   icon = "cat";
   title = ["About Kate"];
+  readonly application_id = "kate:about";
 
   body_container(body: UI.Widgetable[]): HTMLElement {
     return h("div", { class: "kate-os-scroll kate-os-content kate-about-bg" }, [...body]);

--- a/packages/kate-core/source/os/apps/boot.ts
+++ b/packages/kate-core/source/os/apps/boot.ts
@@ -8,6 +8,8 @@ import { h } from "../ui/widget";
 import { Scene } from "../ui/scenes";
 
 export class SceneBoot extends Scene {
+  readonly application_id = "kate:boot";
+
   render() {
     return h("div", { class: "kate-os-logo" }, [
       h("div", { class: "kate-os-logo-image" }, [

--- a/packages/kate-core/source/os/apps/game.ts
+++ b/packages/kate-core/source/os/apps/game.ts
@@ -11,6 +11,10 @@ import { Scene } from "../ui/scenes";
 import { KateButton } from "../../kernel";
 
 export class SceneGame extends Scene {
+  get application_id(): string {
+    return this.process().cart.id;
+  }
+
   constructor(os: KateOS, readonly process: () => KateProcess) {
     super(os, false);
   }

--- a/packages/kate-core/source/os/apps/load-screen.ts
+++ b/packages/kate-core/source/os/apps/load-screen.ts
@@ -9,6 +9,8 @@ import { Scene } from "../ui/scenes";
 import type { KateOS } from "../os";
 
 export class HUD_LoadIndicator extends Scene {
+  readonly application_id = "kate:loading";
+
   constructor(os: KateOS) {
     super(os, true);
   }

--- a/packages/kate-core/source/os/apps/media.ts
+++ b/packages/kate-core/source/os/apps/media.ts
@@ -12,16 +12,15 @@ import { SimpleScene } from "../ui/scenes";
 import { SceneViewMedia } from "./view-media";
 
 export class SceneMedia extends SimpleScene {
+  readonly application_id = "kate:media";
+
   icon = "images";
   title = ["Media gallery"];
   subtitle = h("div", { class: "kate-os-media-status" }, []);
 
   private media = new Map<HTMLElement, Db.Media>();
 
-  constructor(
-    os: KateOS,
-    readonly filter: null | { id: string; title: string }
-  ) {
+  constructor(os: KateOS, readonly filter: null | { id: string; title: string }) {
     super(os);
   }
 
@@ -91,9 +90,7 @@ export class SceneMedia extends SimpleScene {
     if (duration == null) {
       return null;
     } else {
-      return h("div", { class: "kate-os-video-duration" }, [
-        this.format_duration(duration),
-      ]);
+      return h("div", { class: "kate-os-video-duration" }, [this.format_duration(duration)]);
     }
   }
 
@@ -128,8 +125,7 @@ export class SceneMedia extends SimpleScene {
     for (const [button, meta] of this.media) {
       if (meta.id === id) {
         if (button.classList.contains("focus")) {
-          const new_focus =
-            button.previousElementSibling ?? button.nextElementSibling ?? null;
+          const new_focus = button.previousElementSibling ?? button.nextElementSibling ?? null;
           this.os.focus_handler.focus(new_focus as HTMLElement | null);
           button.remove();
           this.media.delete(button);

--- a/packages/kate-core/source/os/apps/settings/audit.ts
+++ b/packages/kate-core/source/os/apps/settings/audit.ts
@@ -5,11 +5,7 @@
  */
 
 import { AuditMessage, AuditResource } from "../../../data";
-import {
-  Observable,
-  fine_grained_relative_date,
-  unreachable,
-} from "../../../utils";
+import { Observable, fine_grained_relative_date, unreachable } from "../../../utils";
 import { Audit } from "../../apis";
 import type { KateOS } from "../../os";
 import * as UI from "../../ui";
@@ -28,6 +24,7 @@ function format_retention(days: number) {
 }
 
 export class SceneAudit extends UI.SimpleScene {
+  readonly application_id = "kate:settings:audit";
   icon = "eye";
   title = ["Audit"];
 
@@ -40,11 +37,7 @@ export class SceneAudit extends UI.SimpleScene {
         click_label: "Change",
         title: `Log retention period`,
         description: `Log entries older than this will be removed automatically to save storage space.`,
-        value: UI.dynamic(
-          config.map<UI.Widgetable>((x) =>
-            format_retention(x.log_retention_days)
-          )
-        ),
+        value: UI.dynamic(config.map<UI.Widgetable>((x) => format_retention(x.log_retention_days))),
         on_click: () => {
           this.select_retention_days(config);
         },
@@ -55,8 +48,7 @@ export class SceneAudit extends UI.SimpleScene {
       UI.link_card(this.os, {
         icon: "eye",
         title: "Audit log",
-        description:
-          "See all actions taken on your behalf and any errors that happened.",
+        description: "See all actions taken on your behalf and any errors that happened.",
         on_click: () => {
           this.os.push_scene(new SceneAuditLog(this.os));
         },
@@ -95,6 +87,7 @@ export class SceneAudit extends UI.SimpleScene {
 }
 
 export class SceneAuditLog extends UI.SimpleScene {
+  readonly application_id = "kate:settings:audit";
   icon = "eye";
   title = ["Audit log"];
   page = new Observable(0);
@@ -158,9 +151,7 @@ export class SceneAuditLog extends UI.SimpleScene {
       UI.dynamic(
         this.current.map<UI.Widgetable>((current) => {
           return UI.klass("kate-ui-logview", [
-            UI.klass("kate-ui-logview-data", [
-              ...current.logs.map((x) => this.render_entry(x)),
-            ]),
+            UI.klass("kate-ui-logview-data", [...current.logs.map((x) => this.render_entry(x))]),
           ]);
         })
       ),
@@ -172,25 +163,17 @@ export class SceneAuditLog extends UI.SimpleScene {
       this.os,
       UI.h("div", { class: "kate-ui-logview-entry", "data-risk": x.risk }, [
         UI.h("div", { class: "kate-ui-logview-entry-heading" }, [
-          UI.h(
-            "div",
-            { class: "kate-ui-logview-process", title: x.process_id },
-            [x.process_id]
-          ),
-          UI.h(
-            "div",
-            { class: "kate-ui-logview-date", title: x.time.toISOString() },
-            [fine_grained_relative_date(x.time)]
-          ),
+          UI.h("div", { class: "kate-ui-logview-process", title: x.process_id }, [x.process_id]),
+          UI.h("div", { class: "kate-ui-logview-date", title: x.time.toISOString() }, [
+            fine_grained_relative_date(x.time),
+          ]),
           UI.h("div", { class: "kate-ui-logview-resources" }, [
             ...[...x.resources.values()].map(render_resource),
           ]),
         ]),
         UI.h("div", { class: "kate-ui-logview-entry-message" }, [x.message]),
         UI.when(x.extra != null, [
-          UI.h("div", { class: "kate-ui-logview-extra" }, [
-            JSON.stringify(x.extra, null, 2),
-          ]),
+          UI.h("div", { class: "kate-ui-logview-extra" }, [JSON.stringify(x.extra, null, 2)]),
         ]),
       ]),
       [
@@ -208,6 +191,7 @@ export class SceneAuditLog extends UI.SimpleScene {
 }
 
 export class SceneAuditEntry extends UI.SimpleScene {
+  readonly application_id = "kate:settings:audit";
   icon = "eye";
   title = ["Audit log"];
 
@@ -224,11 +208,7 @@ export class SceneAuditEntry extends UI.SimpleScene {
     },
   ];
 
-  constructor(
-    os: KateOS,
-    readonly logview: SceneAuditLog,
-    readonly entry: AuditMessage
-  ) {
+  constructor(os: KateOS, readonly logview: SceneAuditLog, readonly entry: AuditMessage) {
     super(os);
   }
 
@@ -238,32 +218,18 @@ export class SceneAuditEntry extends UI.SimpleScene {
     return [
       UI.scroll([
         UI.h("div", { class: "kate-ui-audit-entry" }, [
-          UI.h(
-            "div",
-            { class: "kate-ui-logview-entry-heading", "data-risk": x.risk },
-            [
-              UI.h(
-                "div",
-                { class: "kate-ui-logview-process", title: x.process_id },
-                [x.process_id]
-              ),
-              UI.h("div", { class: "kate-ui-logview-risk" }, [
-                `(${x.risk} risk)`,
-              ]),
-              UI.h(
-                "div",
-                { class: "kate-ui-logview-date", title: x.time.toISOString() },
-                [fine_grained_relative_date(x.time)]
-              ),
-              UI.h("div", { class: "kate-ui-logview-resources" }, [
-                ...[...x.resources.values()].map(render_resource),
-              ]),
-            ]
-          ),
-          UI.h("div", { class: "kate-ui-audit-entry-message" }, [x.message]),
-          UI.h("div", { class: "kate-ui-audit-entry-extra" }, [
-            JSON.stringify(x.extra, null, 2),
+          UI.h("div", { class: "kate-ui-logview-entry-heading", "data-risk": x.risk }, [
+            UI.h("div", { class: "kate-ui-logview-process", title: x.process_id }, [x.process_id]),
+            UI.h("div", { class: "kate-ui-logview-risk" }, [`(${x.risk} risk)`]),
+            UI.h("div", { class: "kate-ui-logview-date", title: x.time.toISOString() }, [
+              fine_grained_relative_date(x.time),
+            ]),
+            UI.h("div", { class: "kate-ui-logview-resources" }, [
+              ...[...x.resources.values()].map(render_resource),
+            ]),
           ]),
+          UI.h("div", { class: "kate-ui-audit-entry-message" }, [x.message]),
+          UI.h("div", { class: "kate-ui-audit-entry-extra" }, [JSON.stringify(x.extra, null, 2)]),
         ]),
       ]),
     ];

--- a/packages/kate-core/source/os/apps/settings/developer.ts
+++ b/packages/kate-core/source/os/apps/settings/developer.ts
@@ -8,6 +8,7 @@ import { SettingsData } from "../../apis";
 import * as UI from "../../ui";
 
 export class SceneDeveloperSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:developer";
   icon = "code";
   title = ["Developer settings"];
 

--- a/packages/kate-core/source/os/apps/settings/gamepad-input.ts
+++ b/packages/kate-core/source/os/apps/settings/gamepad-input.ts
@@ -17,6 +17,7 @@ import {
 import { InteractionHandler } from "../../apis";
 
 export class GamepadInputSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:input";
   icon = "gamepad";
   title = ["Gamepad settings"];
 
@@ -49,6 +50,7 @@ export class GamepadInputSettings extends UI.SimpleScene {
 }
 
 export class TestStandardMappingSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:input";
   icon = "gamepad";
   title = ["Test gamepad input"];
   subtitle = "Hold any button to exit";
@@ -401,6 +403,7 @@ type ConfigMode = {
 };
 
 export class RemapStandardSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:input";
   private mode = new Observable<ConfigMode>(config_modes[0]);
   private updated = new Observable<boolean>(false);
   private _mapping: GamepadMapping[];
@@ -875,6 +878,7 @@ type PairedGamepad = {
 };
 
 export class ChooseActiveGamepadSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:input";
   icon = "gamepad";
   title = ["Choose active gamepad"];
 

--- a/packages/kate-core/source/os/apps/settings/index.ts
+++ b/packages/kate-core/source/os/apps/settings/index.ts
@@ -15,6 +15,7 @@ import { SceneStorageSettings } from "./storage";
 import { SceneUISettings } from "./ui";
 
 export class SceneSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings";
   icon = "gear";
   title = ["Settings"];
 
@@ -34,8 +35,7 @@ export class SceneSettings extends UI.SimpleScene {
       UI.link_card(this.os, {
         icon: "gamepad",
         title: "Controller & Sensors",
-        description:
-          "Configure virtual buttons, keyboard, gamepad, and other input sources",
+        description: "Configure virtual buttons, keyboard, gamepad, and other input sources",
         on_click: () => {
           this.os.push_scene(new SceneInputSettings(this.os));
         },
@@ -44,8 +44,7 @@ export class SceneSettings extends UI.SimpleScene {
       UI.link_card(this.os, {
         icon: "window-maximize",
         title: "User Interface",
-        description:
-          "Configure appearance and audio/visual feedback for KateOS",
+        description: "Configure appearance and audio/visual feedback for KateOS",
         on_click: () => {
           this.os.push_scene(new SceneUISettings(this.os));
         },
@@ -66,8 +65,7 @@ export class SceneSettings extends UI.SimpleScene {
         UI.link_card(this.os, {
           icon: "key",
           title: "Permissions",
-          description:
-            "What cartridges are allowed to do with your device and data",
+          description: "What cartridges are allowed to do with your device and data",
           on_click: () => {
             this.os.push_scene(new ScenePermissions(this.os));
           },
@@ -86,8 +84,7 @@ export class SceneSettings extends UI.SimpleScene {
       UI.link_card(this.os, {
         icon: "eye",
         title: "Audit",
-        description:
-          "See what your console and cartridges have been doing behind the scenes",
+        description: "See what your console and cartridges have been doing behind the scenes",
         on_click: () => {
           this.os.push_scene(new SceneAudit(this.os));
         },

--- a/packages/kate-core/source/os/apps/settings/input.ts
+++ b/packages/kate-core/source/os/apps/settings/input.ts
@@ -9,6 +9,7 @@ import { GamepadInputSettings } from "./gamepad-input";
 import { KeyboardInputSettings } from "./keyboard-input";
 
 export class SceneInputSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:input";
   icon = "gamepad";
   title = ["Controller & Sensors"];
 
@@ -37,8 +38,7 @@ export class SceneInputSettings extends UI.SimpleScene {
       UI.link_card(this.os, {
         icon: "gamepad",
         title: "Control Kate with a standard gamepad",
-        description:
-          "Select a gamepad and configure how it maps to Kate buttons",
+        description: "Select a gamepad and configure how it maps to Kate buttons",
         on_click: () => {
           this.os.push_scene(new GamepadInputSettings(this.os));
         },

--- a/packages/kate-core/source/os/apps/settings/keyboard-input.ts
+++ b/packages/kate-core/source/os/apps/settings/keyboard-input.ts
@@ -11,6 +11,7 @@ import { Deferred, Observable, defer } from "../../../utils";
 import { ButtonChangeEvent, KateButton } from "../../../kernel";
 
 export class KeyboardInputSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:input";
   icon = "keyboard";
   title = ["Keyboard mapping"];
 

--- a/packages/kate-core/source/os/apps/settings/permissions.ts
+++ b/packages/kate-core/source/os/apps/settings/permissions.ts
@@ -20,6 +20,7 @@ type Risk = {
 };
 
 export class ScenePermissions extends UI.SimpleScene {
+  readonly application_id = "kate:settings:permissions";
   icon = "key";
   title = ["Permissions"];
 
@@ -54,9 +55,7 @@ export class ScenePermissions extends UI.SimpleScene {
         };
       })
     );
-    const cartridges = cartridges1.sort((a, b) =>
-      Capability.compare_risk(a.risk, b.risk)
-    );
+    const cartridges = cartridges1.sort((a, b) => Capability.compare_risk(a.risk, b.risk));
     const security = new Observable(this.os.settings.get("security"));
 
     return [
@@ -87,9 +86,7 @@ export class ScenePermissions extends UI.SimpleScene {
 
   render_cartridge_summary(x: Risk) {
     return UI.link_card(this.os, {
-      icon: x.cart.thumbnail_dataurl
-        ? UI.image(x.cart.thumbnail_dataurl)
-        : UI.no_thumbnail(),
+      icon: x.cart.thumbnail_dataurl ? UI.image(x.cart.thumbnail_dataurl) : UI.no_thumbnail(),
       title: x.cart.metadata.presentation.title,
       click_label: "Details",
       value: x.risk,
@@ -121,10 +118,7 @@ export class ScenePermissions extends UI.SimpleScene {
     this.set_security(current, { prompt_for: result });
   }
 
-  async set_security(
-    current: Observable<Security>,
-    changes: Partial<Security>
-  ) {
+  async set_security(current: Observable<Security>, changes: Partial<Security>) {
     current.value = { ...current.value, ...changes };
     await this.os.settings.update("security", (_) => current.value);
     await this.os.audit_supervisor.log("kate:settings", {
@@ -138,6 +132,7 @@ export class ScenePermissions extends UI.SimpleScene {
 }
 
 export class SceneCartridgePermissions extends UI.SimpleScene {
+  readonly application_id = "kate:settings:permissions";
   icon = "key";
   get title() {
     return [this.cart.metadata.presentation.title];
@@ -148,9 +143,7 @@ export class SceneCartridgePermissions extends UI.SimpleScene {
   }
 
   async body() {
-    const grants0 = await this.os.capability_supervisor.all_grants(
-      this.cart.id
-    );
+    const grants0 = await this.os.capability_supervisor.all_grants(this.cart.id);
     const grants = grants0.sort((a, b) =>
       Capability.compare_risk(a.risk_category(), b.risk_category())
     );

--- a/packages/kate-core/source/os/apps/settings/play-habits.ts
+++ b/packages/kate-core/source/os/apps/settings/play-habits.ts
@@ -9,6 +9,7 @@ import { coarse_time_from_minutes, relative_date } from "../../../utils";
 import * as UI from "../../ui";
 
 export class ScenePlayHabitsSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:play-habits";
   icon = "calendar";
   title = ["Play habits"];
 
@@ -34,23 +35,20 @@ export class ScenePlayHabitsSettings extends UI.SimpleScene {
       UI.toggle_cell(this.os, {
         value: data.recently_played,
         title: "Record last played time",
-        description:
-          "Track and store (locally) the last time you played a cartridge.",
+        description: "Track and store (locally) the last time you played a cartridge.",
         on_changed: this.handle_last_played_change,
       }),
       UI.toggle_cell(this.os, {
         value: data.play_times,
         title: "Record total play time",
-        description:
-          "Track and store (locally) how many minutes you've played a cartridge.",
+        description: "Track and store (locally) how many minutes you've played a cartridge.",
         on_changed: this.handle_play_time_change,
       }),
 
       UI.vspace(16),
       UI.button_panel(this.os, {
         title: "Delete all stored play habits",
-        description:
-          "Remove habits of uninstalled games, reset habits of installed games.",
+        description: "Remove habits of uninstalled games, reset habits of installed games.",
         on_click: this.handle_delete,
         dangerous: true,
       }),
@@ -64,9 +62,7 @@ export class ScenePlayHabitsSettings extends UI.SimpleScene {
   async load_history(container: HTMLElement) {
     container.textContent = "";
     const items = [];
-    const carts = new Map(
-      (await this.os.cart_manager.list_all()).map((x) => [x.id, x])
-    );
+    const carts = new Map((await this.os.cart_manager.list_all()).map((x) => [x.id, x]));
     const all_habits = await this.os.play_habits.all_in_database();
     const history = all_habits.map((x) => {
       const cart = carts.get(x.id) ?? null;
@@ -88,9 +84,7 @@ export class ScenePlayHabitsSettings extends UI.SimpleScene {
                 entry.title,
                 entry.installed
                   ? null
-                  : UI.h("em", { style: "margin-left: 8px" }, [
-                      "(not installed)",
-                    ]),
+                  : UI.h("em", { style: "margin-left: 8px" }, ["(not installed)"]),
               ]),
               description: UI.fragment([
                 entry.play_time === 0
@@ -119,9 +113,7 @@ export class ScenePlayHabitsSettings extends UI.SimpleScene {
     UI.append(new UI.VBox(1, [...items]), container);
   }
 
-  handle_play_entry_options = async (
-    entry: PlayHabits & { title: string; installed: boolean }
-  ) => {
+  handle_play_entry_options = async (entry: PlayHabits & { title: string; installed: boolean }) => {
     const result = await this.os.dialog.pop_menu(
       "kate:settings",
       `${entry.title}`,
@@ -143,9 +135,7 @@ export class ScenePlayHabitsSettings extends UI.SimpleScene {
           message: `Play habits deleted for ${entry.id}`,
           extra: { cartridge: entry.id },
         });
-        await this.load_history(
-          this.canvas.querySelector(".play-habit-history")!
-        );
+        await this.load_history(this.canvas.querySelector(".play-habit-history")!);
         return;
       }
     }
@@ -168,9 +158,7 @@ export class ScenePlayHabitsSettings extends UI.SimpleScene {
         type: "kate.habits.deleted.all",
         message: "Play habits deleted for all cartridges",
       });
-      await this.load_history(
-        this.canvas.querySelector(".play-habit-history")!
-      );
+      await this.load_history(this.canvas.querySelector(".play-habit-history")!);
     }
   };
 

--- a/packages/kate-core/source/os/apps/settings/recovery.ts
+++ b/packages/kate-core/source/os/apps/settings/recovery.ts
@@ -7,6 +7,7 @@
 import * as UI from "../../ui";
 
 export class SceneRecovery extends UI.SimpleScene {
+  readonly application_id = "kate:settings:recovery";
   icon = "stethoscope";
   title = ["Diagnostics & Recovery"];
 
@@ -20,8 +21,7 @@ export class SceneRecovery extends UI.SimpleScene {
       UI.vspace(16),
 
       UI.when(
-        this.os.kernel.console.options.mode === "web" &&
-          this.os.app_resources.worker != null,
+        this.os.kernel.console.options.mode === "web" && this.os.app_resources.worker != null,
         [
           UI.button_panel(this.os, {
             title: "Refresh cache",
@@ -80,13 +80,9 @@ export class SceneRecovery extends UI.SimpleScene {
 
   refresh_cache = async () => {
     try {
-      await this.os.dialog.progress(
-        "kate:recovery",
-        "Refreshing cache",
-        async (progress) => {
-          await this.os.app_resources.refresh_cache();
-        }
-      );
+      await this.os.dialog.progress("kate:recovery", "Refreshing cache", async (progress) => {
+        await this.os.app_resources.refresh_cache();
+      });
       location.reload();
     } catch (error) {
       console.error(`[Kate] failed to refresh cache:`, error);

--- a/packages/kate-core/source/os/apps/settings/storage.ts
+++ b/packages/kate-core/source/os/apps/settings/storage.ts
@@ -11,6 +11,7 @@ import * as UI from "../../ui";
 import { SceneMedia } from "../media";
 
 export class SceneStorageSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:storage";
   icon = "hard-drive";
   title = ["Storage"];
 
@@ -41,9 +42,7 @@ export class SceneStorageSettings extends UI.SimpleScene {
 
     return [
       UI.section({
-        title: `Storage summary (${from_bytes(
-          estimates.totals.quota ?? used_total
-        )})`,
+        title: `Storage summary (${from_bytes(estimates.totals.quota ?? used_total)})`,
         contents: [
           UI.stack_bar({
             total: estimates.totals.quota ?? used_total,
@@ -52,9 +51,7 @@ export class SceneStorageSettings extends UI.SimpleScene {
               estimates.totals.quota != null
                 ? {
                     title: "Free",
-                    display_value: from_bytes(
-                      estimates.totals.quota - estimates.totals.used
-                    ),
+                    display_value: from_bytes(estimates.totals.quota - estimates.totals.used),
                   }
                 : undefined,
             components: [
@@ -92,9 +89,9 @@ export class SceneStorageSettings extends UI.SimpleScene {
       title: x.title,
       click_label: "Details",
       value: from_bytes(x.usage.total_in_bytes),
-      description: `Last used: ${relative_date(
-        x.dates.last_used
-      )} | Last updated: ${relative_date(x.dates.last_modified)}`,
+      description: `Last used: ${relative_date(x.dates.last_used)} | Last updated: ${relative_date(
+        x.dates.last_modified
+      )}`,
       on_click: () => {
         this.os.push_scene(new SceneCartridgeStorageSettings(this.os, x));
       },
@@ -103,6 +100,7 @@ export class SceneStorageSettings extends UI.SimpleScene {
 }
 
 export class SceneCartridgeStorageSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:storage";
   icon = "hard-drive";
   get title() {
     return [this.app.title];
@@ -123,9 +121,7 @@ export class SceneCartridgeStorageSettings extends UI.SimpleScene {
       return;
     }
 
-    const app = await this.os.storage_manager.try_estimate_cartridge(
-      this.app.id
-    );
+    const app = await this.os.storage_manager.try_estimate_cartridge(this.app.id);
     let body: UI.Widgetable[];
     if (app != null) {
       this.app = app;
@@ -157,23 +153,18 @@ export class SceneCartridgeStorageSettings extends UI.SimpleScene {
         )})`,
         click_label: "Manage",
         on_click: () => {
-          this.os.push_scene(
-            new SceneMedia(this.os, { id: this.app.id, title: this.app.title })
-          );
+          this.os.push_scene(new SceneMedia(this.os, { id: this.app.id, title: this.app.title }));
         },
       }),
       UI.link_card(this.os, {
         icon: "hard-drive",
         title: "Manage save data",
         description: `${from_bytes(
-          this.app.usage.data.size_in_bytes +
-            this.app.usage.shared_data.size_in_bytes
+          this.app.usage.data.size_in_bytes + this.app.usage.shared_data.size_in_bytes
         )}`,
         click_label: "Manage",
         on_click: () => {
-          this.os.push_scene(
-            new SceneCartridgeSaveDataSettings(this.os, this.app)
-          );
+          this.os.push_scene(new SceneCartridgeSaveDataSettings(this.os, this.app));
         },
       }),
       UI.when(this.os.kernel.console.options.mode !== "single", [
@@ -202,34 +193,26 @@ export class SceneCartridgeStorageSettings extends UI.SimpleScene {
           `,
           ]),
         ]),
-        UI.when(
-          this.app.status === "active" &&
-            !this.os.processes.is_running(this.app.id),
-          [
-            UI.vspace(16),
-            UI.button_panel(this.os, {
-              title: "Archive cartridge",
-              description: `Cartridge files will be deleted, save data and media will be kept.
+        UI.when(this.app.status === "active" && !this.os.processes.is_running(this.app.id), [
+          UI.vspace(16),
+          UI.button_panel(this.os, {
+            title: "Archive cartridge",
+            description: `Cartridge files will be deleted, save data and media will be kept.
                             Reinstalling the cartridge will bring it back to the current state`,
-              dangerous: true,
-              on_click: () => this.archive_cartridge(),
-            }),
-          ]
-        ),
-        UI.when(
-          this.app.status !== "inactive" &&
-            !this.os.processes.is_running(this.app.id),
-          [
-            UI.vspace(16),
-            UI.button_panel(this.os, {
-              title: "Delete all data",
-              description: `Cartridge files and save data will be deleted, media will be kept.
+            dangerous: true,
+            on_click: () => this.archive_cartridge(),
+          }),
+        ]),
+        UI.when(this.app.status !== "inactive" && !this.os.processes.is_running(this.app.id), [
+          UI.vspace(16),
+          UI.button_panel(this.os, {
+            title: "Delete all data",
+            description: `Cartridge files and save data will be deleted, media will be kept.
                             Reinstalling will not restore the save data.`,
-              dangerous: true,
-              on_click: () => this.delete_all_data(),
-            }),
-          ]
-        ),
+            dangerous: true,
+            on_click: () => this.delete_all_data(),
+          }),
+        ]),
       ],
     });
   }
@@ -300,8 +283,7 @@ export class SceneCartridgeStorageSettings extends UI.SimpleScene {
             component("Cartridge", this.app.usage.cartridge_size_in_bytes),
             component(
               "Saves",
-              this.app.usage.data.size_in_bytes +
-                this.app.usage.shared_data.size_in_bytes
+              this.app.usage.data.size_in_bytes + this.app.usage.shared_data.size_in_bytes
             ),
             component("Media", this.app.usage.media.size_in_bytes),
           ],
@@ -312,6 +294,7 @@ export class SceneCartridgeStorageSettings extends UI.SimpleScene {
 }
 
 class SceneCartridgeSaveDataSettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:storage";
   icon = "hard-drive";
   get title() {
     return [this.app.title];
@@ -332,9 +315,7 @@ class SceneCartridgeSaveDataSettings extends UI.SimpleScene {
       return;
     }
 
-    const app = await this.os.storage_manager.try_estimate_cartridge(
-      this.app.id
-    );
+    const app = await this.os.storage_manager.try_estimate_cartridge(this.app.id);
     let body: UI.Widgetable[];
     if (app != null) {
       this.app = app;
@@ -385,13 +366,10 @@ class SceneCartridgeSaveDataSettings extends UI.SimpleScene {
             free: {
               title: "Free",
               display_value: from_bytes(
-                this.app.quota.data.size_in_bytes -
-                  this.app.usage.data.size_in_bytes
+                this.app.quota.data.size_in_bytes - this.app.usage.data.size_in_bytes
               ),
             },
-            components: [
-              component("In use", this.app.usage.data.size_in_bytes),
-            ],
+            components: [component("In use", this.app.usage.data.size_in_bytes)],
           }),
         ]),
         UI.vspace(16),
@@ -404,13 +382,10 @@ class SceneCartridgeSaveDataSettings extends UI.SimpleScene {
             free: {
               title: "Free",
               display_value: from_bytes(
-                this.app.quota.shared_data.size_in_bytes -
-                  this.app.usage.shared_data.size_in_bytes
+                this.app.quota.shared_data.size_in_bytes - this.app.usage.shared_data.size_in_bytes
               ),
             },
-            components: [
-              component("In use", this.app.usage.shared_data.size_in_bytes),
-            ],
+            components: [component("In use", this.app.usage.shared_data.size_in_bytes)],
           }),
         ]),
       ],
@@ -427,15 +402,8 @@ class SceneCartridgeSaveDataSettings extends UI.SimpleScene {
       ok: "Delete save data",
     });
     if (ok) {
-      await this.os.processes.terminate(
-        this.app.id,
-        "kate:settings",
-        "Deleted save data."
-      );
-      await this.os.object_store.delete_cartridge_data(
-        this.app.id,
-        this.app.version_id
-      );
+      await this.os.processes.terminate(this.app.id, "kate:settings", "Deleted save data.");
+      await this.os.object_store.delete_cartridge_data(this.app.id, this.app.version_id);
       await this.os.audit_supervisor.log("kate:settings", {
         resources: ["kate:storage"],
         risk: "low",

--- a/packages/kate-core/source/os/apps/settings/ui.ts
+++ b/packages/kate-core/source/os/apps/settings/ui.ts
@@ -10,6 +10,7 @@ import { SettingsData } from "../../apis/settings";
 import * as UI from "../../ui";
 
 export class SceneUISettings extends UI.SimpleScene {
+  readonly application_id = "kate:settings:ui";
   icon = "window-maximize";
   title = ["User Interface"];
 

--- a/packages/kate-core/source/os/apps/text-file.ts
+++ b/packages/kate-core/source/os/apps/text-file.ts
@@ -11,6 +11,8 @@ import { Scene } from "../ui/scenes";
 import { KateButton } from "../../kernel";
 
 export class SceneTextFile extends Scene {
+  readonly application_id = "kate:view-document";
+
   constructor(
     os: KateOS,
     private title: string,

--- a/packages/kate-core/source/os/apps/view-media.ts
+++ b/packages/kate-core/source/os/apps/view-media.ts
@@ -14,6 +14,8 @@ import { Scene } from "../ui/scenes";
 import { KateButton } from "../../kernel";
 
 export class SceneViewMedia extends Scene {
+  readonly application_id = "kate:media";
+
   private url: string | null = null;
 
   constructor(os: KateOS, readonly media_list: SceneMedia, readonly media: Db.Media) {

--- a/packages/kate-core/source/os/ui/scenes.ts
+++ b/packages/kate-core/source/os/ui/scenes.ts
@@ -21,7 +21,9 @@ import {
 } from "./widget";
 
 export abstract class Scene {
+  abstract readonly application_id: string;
   readonly canvas: HTMLElement;
+
   constructor(protected os: KateOS, upscaled: boolean) {
     this.canvas = h("div", { class: `kate-os-screen ${upscaled ? "upscaled" : ""}` }, []);
   }
@@ -41,6 +43,7 @@ export abstract class Scene {
   abstract render(): Widgetable;
 
   on_attached() {}
+
   on_detached() {}
 
   close() {

--- a/www/css/kate.css
+++ b/www/css/kate.css
@@ -140,12 +140,17 @@ body {
   border-radius: 100%;
 }
 
-.kate-resource-trusted-mode {
+.kate-current-process-indicator {
   font-family: "Font Awesome 6 Free";
 }
 
-.kate-resource-trusted-mode::before {
+.kate-current-process-indicator[data-trusted]::before {
   content: "\f023";
+  display: block;
+}
+
+.kate-current-process-indicator:not([data-trusted])::before {
+  content: "\f219";
   display: block;
 }
 

--- a/www/css/os/screens/home.css
+++ b/www/css/os/screens/home.css
@@ -14,6 +14,7 @@
 
 .kate-os-carts-scroll {
   overflow-x: scroll;
+  overflow-y: hidden;
   padding: 5px 0;
   scroll-behavior: smooth;
   scroll-padding: 30px;
@@ -28,7 +29,6 @@
 .kate-os-carts-scroll::-webkit-scrollbar {
   height: 0;
 }
-
 
 .kate-os-carts {
   margin: 15px;


### PR DESCRIPTION
Trusted mode in Kate was a bit of a special code only applied to dialogs, but the intention has always been to help people understand if the screen they were looking at and interacting with came from a trusted source (e.g.: the Kate OS itself), or belonged to an untrusted cartridge. The primary motivation for this is to prevent things like phishing attacks.

E.g.: imagine you're doing something on your regular operating system in a random application. You click a button, which then shows an OS dialog to you asking you to provide administrator rights by typing in your password so that some action can be finished. There's usually not much of a way of knowing where this dialog comes from because it has no distinctive indication that is impossible to mimic from a regular application. You then end up having to trust that the request is reasonable enough to provide your password in this random text input, which will end up god-knows-where. The web improves this slightly by showing you the domain you're currently interacting with on each page (though not always by default on a phone).

When the trusted mode and resource indicators were added to Kate at first, they were meant to address this category of problems. But they weren't quite thought through at the time, as prototyping a usable console was more of a goal, so they ended up being confusing at best. This patch tries to put some principled design behind the idea, while keeping the same goal.

A previous patch had already merged the trusted mode indicator with the resource indicator area, which this patch maintains and builds upon. The new thing in this patch is that every scene (the Kate equivalent of a "window" or "screen" in other operating systems) is branded with an application identifier, which is unforgeable by cartridges. This identifier then allows the OS to know where the currently showing scene originates from. To improve how we communicate this to users, we rely on the fact that Kate only allows one scene to be on foreground at any given time---so we repurpose the resource indicator area to have an indicator of whether the current scene belongs to a trusted application or an untrusted one, similar to how web browsers display a padlock symbol or a different symbol depending on whether the current page is using an encrypted connection or not.

Though this may change in the future if Kate supports multiple foreground processes (not currently planned), the current implementation has a single field to hold the current process and its trust level. The OS scene manager then takes care of updating this field every time the scene it is displaying changes. That makes the whole trust indication consistent throughout the OS---like in web browsers. It also prevents theoretical (and not so theoretical) attacks that were not mitigated by the previous approach, such as a cartridge mimic'ing a regular OS settings screen.

Note that, as a fully capability-based operating system, Kate already mitigates privilege escalation attacks by design. That is, even if a cartridge had managed to acquire a user's password that is used somewhere within the operating system, it would have no way of using that password. HOWEVER, especially when combined with network access, it could always exfiltrate this collected data elsewhere, which would then enable some more indirect attacks. The current implementation closes that gap.