### PR TITLE
Improve text and pointer inputs

### DIFF
--- a/ecosystem/importer/kate.json
+++ b/ecosystem/importer/kate.json
@@ -2,12 +2,12 @@
   "id": "qteati.me/kate-importer",
   "version": {
     "major": 0,
-    "minor": 5
+    "minor": 6
   },
   "release": {
     "year": 2023,
-    "month": 8,
-    "day": 11
+    "month": 10,
+    "day": 21
   },
   "metadata": {
     "presentation": {

--- a/ecosystem/importer/source/index.ts
+++ b/ecosystem/importer/source/index.ts
@@ -9,6 +9,7 @@ import { SceneMain } from "./scenes/main";
 const root = document.querySelector("#canvas")! as HTMLElement;
 const ui = new UI(root, {
   on_key_pressed: KateAPI.input.on_key_pressed,
+  on_pointer_click: KateAPI.pointer_input.on_clicked,
 });
 
 async function main() {

--- a/packages/kate-api/source/pointer-input.ts
+++ b/packages/kate-api/source/pointer-input.ts
@@ -7,6 +7,8 @@
 import type { KateTimer } from "./timer";
 import { EventStream } from "./util";
 
+export type PointerButton = "primary" | "alternate";
+
 export type PointerLocation = {
   x: number;
   y: number;
@@ -14,13 +16,12 @@ export type PointerLocation = {
 
 export type PointerClick = {
   location: PointerLocation;
-  button: number;
+  button: PointerButton;
 };
 
 export class KatePointerInput {
   readonly on_moved = new EventStream<PointerLocation>();
   readonly on_clicked = new EventStream<PointerClick>();
-  readonly on_alternate = new EventStream<PointerClick>();
   readonly on_down = new EventStream<PointerClick>();
   readonly on_up = new EventStream<PointerClick>();
 
@@ -68,6 +69,15 @@ export class KatePointerInput {
 
     this._started = true;
 
+    function to_button(id: number): PointerButton {
+      switch (id) {
+        case 0:
+          return "primary";
+        default:
+          return "alternate";
+      }
+    }
+
     cover.addEventListener("mousemove", (ev) => {
       this._location.x = ev.pageX;
       this._location.y = ev.pageY;
@@ -78,7 +88,7 @@ export class KatePointerInput {
       this._buttons.set(ev.button, 1);
       this.on_down.emit({
         location: this.location,
-        button: ev.button,
+        button: to_button(ev.button),
       });
     });
 
@@ -86,7 +96,7 @@ export class KatePointerInput {
       this._buttons.set(ev.button, -1);
       this.on_up.emit({
         location: this.location,
-        button: ev.button,
+        button: to_button(ev.button),
       });
     });
 
@@ -94,15 +104,15 @@ export class KatePointerInput {
       ev.preventDefault();
       this.on_clicked.emit({
         location: this.location,
-        button: ev.button,
+        button: "primary",
       });
     });
 
     cover.addEventListener("contextmenu", (ev) => {
       ev.preventDefault();
-      this.on_alternate.emit({
+      this.on_clicked.emit({
         location: this.location,
-        button: ev.button,
+        button: "alternate",
       });
     });
 

--- a/packages/kate-bridges/source/pointer-input.ts
+++ b/packages/kate-bridges/source/pointer-input.ts
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import type { PointerButton } from "../../kate-api/source/pointer-input";
+
 // This proxy translates Kate's pointer input API (mouse movement/click)
 // into regular web pointer events. You provide an element that will
 // receive the events.
@@ -29,6 +31,16 @@ void (function () {
   function do_monitor(element: HTMLElement) {
     const pointer = KateAPI.pointer_input;
     const bounds = element.getBoundingClientRect();
+    function to_button_id(button: PointerButton) {
+      switch (button) {
+        case "primary":
+          return 0;
+        case "alternate":
+          return 1;
+        default:
+          throw new Error(`invalid button ${button}`);
+      }
+    }
     function translate_location(ev: KateTypes.PointerLocation) {
       return {
         x: ev.x - bounds.x,
@@ -54,7 +66,7 @@ void (function () {
         screenY: loc.y,
         clientX: loc.x,
         clientY: loc.y,
-        button: ev0.button,
+        button: to_button_id(ev0.button),
       });
     }
 
@@ -76,11 +88,8 @@ void (function () {
     });
 
     pointer.on_clicked.listen((ev0) => {
-      element.dispatchEvent(make_press_event("click", ev0));
-    });
-
-    pointer.on_alternate.listen((ev0) => {
-      element.dispatchEvent(make_press_event("contextmenu", ev0));
+      const type = ev0.button === "primary" ? "click" : "contextmenu";
+      element.dispatchEvent(make_press_event(type, ev0));
     });
   }
 

--- a/packages/kate-core/source/host.types.ts
+++ b/packages/kate-core/source/host.types.ts
@@ -14,6 +14,10 @@ declare global {
       lock(keyCodes: string[]): Promise<void>;
       unlock(): void;
     };
+
+    virtualKeyboard?: {
+      overlaysContent: boolean;
+    };
   }
 
   interface KeyboardLayoutMap {

--- a/packages/kate-core/source/loader.ts
+++ b/packages/kate-core/source/loader.ts
@@ -43,6 +43,10 @@ async function main() {
     return null;
   });
 
+  if ("virtualKeyboard" in navigator && navigator.virtualKeyboard != null) {
+    navigator.virtualKeyboard.overlaysContent = true;
+  }
+
   // Run Kate
   const kate = Kate.kernel.KateKernel.from_root(document.querySelector(".kate-case")!, {
     mode: "web",

--- a/packages/kate-core/source/os/apis/dialog.ts
+++ b/packages/kate-core/source/os/apis/dialog.ts
@@ -147,6 +147,7 @@ export class KateDialog {
             }),
           ]),
         ]),
+        UI.h("div", { class: "kate-hud-virtual-keyboard-placeholder" }, []),
       ],
       null,
       "text-input"

--- a/www/css/os/hud/base-dialog.css
+++ b/www/css/os/hud/base-dialog.css
@@ -51,3 +51,16 @@
 .kate-hud-dialog-container > * {
   width: 100%;
 }
+
+.kate-hud-virtual-keyboard-placeholder {
+  display: block;
+  overflow: hidden;
+  flex-grow: 0;
+  flex-shrink: 1;
+  background: var(--color-border);
+  height: env(keyboard-inset-height, 0px);
+}
+
+.kate-ui-text-input-container {
+  max-height: 100%;
+}


### PR DESCRIPTION
This patch does some better handling of virtual keyboard-based text input by using the Virtual Keyboard API to allow text input controls to move around to accomodate the keyboard on the screen. This unfortunately is experimental, only implemented in Chromium, and even there support seems spotty at best. But it does improve things a bit on Android phones at least.

This patch also includes the long-overdue support for pointer clicks in appui, so appui cartridges like the Importer should be usable with touch controls as well moving forward.