### PR TITLE
Move media storage to new partitioned file storage

### DIFF
--- a/packages/kate-core/source/data/db.ts
+++ b/packages/kate-core/source/data/db.ts
@@ -6,4 +6,4 @@
 
 import * as Db from "../db-schema";
 
-export const kate = new Db.DatabaseSchema("kate", 15);
+export const kate = new Db.DatabaseSchema("kate", 16);

--- a/packages/kate-core/source/data/media.ts
+++ b/packages/kate-core/source/data/media.ts
@@ -14,6 +14,9 @@ export type Media = {
   thumbnail_dataurl: string;
   video_length: number | null;
   size: number;
+  // since v16
+  file_id: string;
+  mime: string;
 };
 export const media_store = kate.table1<Media, "id">({
   since: 4,
@@ -26,16 +29,4 @@ export const idx_media_store_by_cart = media_store.index1({
   name: "by_cart_v2",
   path: "cart_id",
   unique: false,
-});
-
-export type MediaFile = {
-  id: string;
-  mime: string;
-  data: Uint8Array;
-};
-export const media_files = kate.table1<MediaFile, "id">({
-  since: 4,
-  name: "media_files",
-  path: "id",
-  auto_increment: false,
 });

--- a/packages/kate-core/source/data/migrations/deprecated.ts
+++ b/packages/kate-core/source/data/migrations/deprecated.ts
@@ -114,3 +114,17 @@ export const idx_cartridge_quota_by_cartridge = cartridge_quota.index1({
   multi_entry: false,
   unique: false,
 });
+
+// == v16 ======================================================================
+export type MediaFile = {
+  id: string;
+  mime: string;
+  data: Uint8Array;
+};
+export const media_files = kate.table1<MediaFile, "id">({
+  since: 4,
+  deprecated_since: 16,
+  name: "media_files",
+  path: "id",
+  auto_increment: false,
+});

--- a/packages/kate-core/source/data/migrations/index.ts
+++ b/packages/kate-core/source/data/migrations/index.ts
@@ -6,3 +6,4 @@
 
 import "./deprecated";
 import "./v15";
+import "./v16";

--- a/packages/kate-core/source/data/migrations/v15.ts
+++ b/packages/kate-core/source/data/migrations/v15.ts
@@ -39,7 +39,7 @@ kate.data_migration({
         continue;
       }
       console.debug(`[kate:db] Migrating files for ${cartridge.id} ${cartridge.version}`);
-      const bucket = await partition.create();
+      const bucket = await partition.create(null);
       try {
         const nodes = new Map<string, Node>();
         for (const file of cartridge.files) {

--- a/packages/kate-core/source/data/migrations/v16.ts
+++ b/packages/kate-core/source/data/migrations/v16.ts
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { kate } from "../db";
+import type { KateOS } from "../../os";
+import { media_store, type Media } from "../media";
+import { media_files } from "./deprecated";
+
+type OldMedia = Omit<Media, "file_id" | "mime">;
+
+// -- Migrations
+kate.data_migration({
+  id: "v16/media",
+  description: "Migrating media files to new storage",
+  since: 16,
+  async process(db, os0) {
+    const os = os0 as KateOS;
+    const store = os.file_store;
+    const bucket = await store.get_kernel_bucket("media");
+    const mapping = new Map<string, { mime: string; id: string }>();
+
+    // -- First copy all files to the backing file storage
+    try {
+      const files: OldMedia[] = await db.transaction([media_store], "readonly", async (txn) => {
+        return txn.get_table1(media_store).get_all();
+      });
+      console.debug(`[kate:db] Moving ${files.length} media files to new storage format`);
+      for (const file of files) {
+        const data = await db.transaction([media_files], "readonly", async (txn) => {
+          return txn.get_table1(media_files).get(file.id);
+        });
+        const entry = await bucket.put(data.data);
+        mapping.set(file.id, { mime: data.mime, id: entry.id });
+      }
+    } catch (e) {
+      for (const entry of mapping.values()) {
+        await bucket.file(entry.id).delete();
+      }
+      console.error("[kate:db] Failed to migrate media files", e);
+      throw new Error(`[kate:db] Failed to migrate media files ${e}`);
+    }
+
+    // -- Patch all media entries
+    await db.transaction([media_store, media_files], "readwrite", async (txn) => {
+      const media = txn.get_table1(media_store);
+      const files = txn.get_table1(media_files);
+
+      console.debug(`[kate:db] Patching media entries to point to new storage`);
+      for (const entry of await media.get_all()) {
+        const mapped_file = mapping.get(entry.id);
+        if (mapped_file == null) {
+          throw new Error(`[kate:db] Inconsistent media database`);
+        }
+
+        media.put({
+          ...entry,
+          file_id: mapped_file.id,
+          mime: mapped_file.mime,
+        });
+      }
+
+      console.debug(`[kate:db] Cleaning up old tables`);
+      await files.clear();
+    });
+  },
+});

--- a/packages/kate-core/source/os/apps/view-media.ts
+++ b/packages/kate-core/source/os/apps/view-media.ts
@@ -37,9 +37,8 @@ export class SceneViewMedia extends Scene {
 
   async on_attached(): Promise<void> {
     this.os.focus_handler.listen(this.canvas, this.handle_key_pressed);
-    const file = await this.os.capture.read_file(this.media.id);
-    const blob = new Blob([file.data], { type: file.mime });
-    this.url = URL.createObjectURL(blob);
+    const { handle } = await this.os.capture.read_file(this.media.id);
+    this.url = URL.createObjectURL(handle);
     this.render_media(this.url);
   }
 


### PR DESCRIPTION
Continuing the move from giant blobs in IndexedDB to OPFS-backed partitioned file storage, this moves media files to the new partitioned file storage. Note that we cannot yet relax the restrictions on video recording sizes because we require all chunks to fit in memory. We may relax things by writing chunks to a temporary bucket instead of holding them in memory --- this would also open up the possibility of doing higher quality recording.