### PR TITLE
Temporary buckets

### DIFF
--- a/ecosystem/importer/kate.json
+++ b/ecosystem/importer/kate.json
@@ -51,6 +51,12 @@
       {
         "type": "show-dialogs",
         "reason": "For text input and error feedback"
+      },
+      {
+        "type": "store-temporary-files",
+        "reason": "Unpacking zip files and generating cartridges",
+        "max_size_mb": 8192,
+        "optional": false
       }
     ]
   },

--- a/ecosystem/importer/kate.json
+++ b/ecosystem/importer/kate.json
@@ -2,12 +2,12 @@
   "id": "qteati.me/kate-importer",
   "version": {
     "major": 0,
-    "minor": 9
+    "minor": 10
   },
   "release": {
-    "year": 2023,
-    "month": 12,
-    "day": 26
+    "year": 2024,
+    "month": 1,
+    "day": 21
   },
   "metadata": {
     "presentation": {

--- a/ecosystem/importer/source/deps/utils.ts
+++ b/ecosystem/importer/source/deps/utils.ts
@@ -9,4 +9,5 @@ export * from "../../../../packages/util/build/graphics";
 export * from "../../../../packages/util/build/pathname";
 export * from "../../../../packages/util/build/assert";
 export * from "../../../../packages/util/build/observable";
+export * from "../../../../packages/util/build/unit";
 export * as binary from "../../../../packages/util/build/binary";

--- a/ecosystem/importer/source/scenes/review.ts
+++ b/ecosystem/importer/source/scenes/review.ts
@@ -163,9 +163,9 @@ export class SceneReview extends UIScene {
         process: async (progress) => {
           const cartridge = await candidate.make_cartridge();
           progress.set_message(["Packing cartridge..."]);
-          const bytes = encode_whole(cartridge);
+          const file = await encode_whole(cartridge);
           progress.set_message(["Preparing to install..."]);
-          await KateAPI.cart_manager.install(bytes);
+          await KateAPI.cart_manager.install_from_file(file);
         },
       });
     } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "kate",
-  "version": "0.23.10-a3",
+  "version": "0.24.2-a1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.23.10-a3",
+      "version": "0.24.2-a1",
       "dependencies": {
         "glob": "^8.1.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.38.1",
         "@types/node": "^18.15.11",
-        "electron": "^27.0.2",
+        "electron": "27.0.2",
         "express": "^4.18.2",
         "playwright": "^1.38.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@electron/get": {
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2768,9 +2768,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "electron": "27.0.2",
     "express": "^4.18.2",
     "playwright": "^1.38.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.3.3"
   }
 }

--- a/packages/kate-api/source/cart-manager.ts
+++ b/packages/kate-api/source/cart-manager.ts
@@ -5,6 +5,7 @@
  */
 
 import type { KateIPC } from "./channel";
+import type { KateFile } from "./file-store";
 
 export class KateCartManager {
   #channel: KateIPC;
@@ -13,9 +14,16 @@ export class KateCartManager {
     this.#channel = channel;
   }
 
-  async install(cartridge: Uint8Array) {
-    await this.#channel.call("kate:cart-manager.install", { cartridge }, [
+  async install_from_bytes(cartridge: Uint8Array) {
+    await this.#channel.call("kate:cart-manager.install-from-bytes", { cartridge }, [
       cartridge.buffer,
     ]);
+  }
+
+  async install_from_file(file: KateFile) {
+    await this.#channel.call("kate:cart-manager.install-from-file", {
+      bucket_id: file.bucket.id,
+      file_id: file.id,
+    });
   }
 }

--- a/packages/kate-api/source/file-store.ts
+++ b/packages/kate-api/source/file-store.ts
@@ -1,0 +1,106 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import type { KateIPC } from "./channel";
+
+export type FileId = string & { __file_id: true };
+
+export class KateFileStore {
+  #channel: KateIPC;
+  constructor(channel: KateIPC) {
+    this.#channel = channel;
+  }
+
+  async make_temporary(size: number) {
+    const id = (await this.#channel.call("kate:file-store.make-temporary-bucket", {
+      size,
+    })) as string;
+    return new FileBucket(this.#channel, id);
+  }
+}
+
+export class FileBucket {
+  #channel: KateIPC;
+  private inodes = new Map<string, FileId>();
+
+  constructor(channel: KateIPC, readonly id: string) {
+    this.#channel = channel;
+  }
+
+  private get_id(name: string) {
+    const id = this.inodes.get(name);
+    if (id == null) {
+      throw new Error(`File ${name} not found`);
+    }
+    return id;
+  }
+
+  async delete() {
+    await this.#channel.call("kate:file-store.delete-bucket", { bucket_id: this.id });
+  }
+
+  async create_file(name: string, data: Uint8Array) {
+    if (this.inodes.has(name)) {
+      throw new Error(`File ${name} already exists`);
+    }
+    this.inodes.set(name, "" as FileId);
+    const id = (await this.#channel.call("kate:file-store.put-file", {
+      bucket_id: this.id,
+      data,
+    })) as string;
+    this.inodes.set(name, id as FileId);
+    return new KateFile(this.#channel, this, id);
+  }
+
+  async replace_file(name: string, data: Uint8Array) {
+    await this.delete_file(name);
+    return this.create_file(name, data);
+  }
+
+  async open_file(name: string) {
+    const id = this.get_id(name);
+    return new KateFile(this.#channel, this, id);
+  }
+
+  async delete_file(name: string) {
+    const id = this.get_id(name);
+    await this.#channel.call("kate:file-store.delete-file", { bucket_id: this.id, file_id: id });
+  }
+}
+
+export class KateFile {
+  #channel: KateIPC;
+  constructor(channel: KateIPC, readonly bucket: FileBucket, readonly id: string) {
+    this.#channel = channel;
+  }
+
+  async size() {
+    return (await this.#channel.call("kate:file-store.file-size", {
+      bucket_id: this.bucket.id,
+      file_id: this.id,
+    })) as number;
+  }
+
+  async read_all() {
+    return this.read(0);
+  }
+
+  async read(offset: number, size?: number) {
+    return (await this.#channel.call("kate:file-store.read-file", {
+      bucket_id: this.bucket.id,
+      file_id: this.id,
+      offset,
+      size,
+    })) as Uint8Array;
+  }
+
+  async append(data: Uint8Array) {
+    await this.#channel.call("kate:file-store.append-file", {
+      bucket_id: this.bucket.id,
+      file_id: this.id,
+      data,
+    });
+  }
+}

--- a/packages/kate-api/source/index.ts
+++ b/packages/kate-api/source/index.ts
@@ -11,6 +11,7 @@ import { KateCartManager } from "./cart-manager";
 import { KateIPC } from "./channel";
 import { DeviceFileHandle, KateDeviceFileAccess } from "./device-file";
 import { KateDialogs } from "./dialog";
+import { KateFileStore } from "./file-store";
 import { InputKey, KateInput } from "./input";
 import { KateObjectStore } from "./object-store";
 import { KatePointerInput, PointerClick, PointerLocation } from "./pointer-input";
@@ -26,6 +27,8 @@ export const events = channel.events;
 export const cart_fs = new KateCartFS(channel);
 
 export const store = new KateObjectStore(channel);
+
+export const file_store = new KateFileStore(channel);
 
 export const timer = new KateTimer();
 timer.setup();

--- a/packages/kate-api/source/index.ts
+++ b/packages/kate-api/source/index.ts
@@ -11,7 +11,7 @@ import { KateCartManager } from "./cart-manager";
 import { KateIPC } from "./channel";
 import { DeviceFileHandle, KateDeviceFileAccess } from "./device-file";
 import { KateDialogs } from "./dialog";
-import { KateFileStore } from "./file-store";
+import { FileBucket, KateFile, KateFileStore } from "./file-store";
 import { InputKey, KateInput } from "./input";
 import { KateObjectStore } from "./object-store";
 import { KatePointerInput, PointerClick, PointerLocation } from "./pointer-input";
@@ -79,6 +79,7 @@ export type KateAPI = {
   events: typeof events;
   cart_fs: typeof cart_fs;
   store: typeof store;
+  file_store: typeof file_store;
   input: typeof input;
   pointer_input: typeof pointer_input;
   timer: typeof timer;
@@ -102,6 +103,8 @@ declare global {
       PointerLocation,
       PointerClick,
       DeviceFileHandle,
+      FileBucket,
+      KateFile,
     };
   }
 }

--- a/packages/kate-core/source/capabilities/definitions.ts
+++ b/packages/kate-core/source/capabilities/definitions.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { ContextualCapability } from "../cart";
+import { ContextualCapability, PassiveCapability } from "../cart";
 import type {
   CapabilityGrant,
   CapabilityType,
@@ -241,6 +241,48 @@ export class ShowDialogs extends SwitchCapability<"show-dialogs"> {
       throw new Error(`Unexpected capability: ${capability.type}`);
     }
     return new ShowDialogs(cart_id, true);
+  }
+
+  update(grant: boolean): void {
+    this._grant_configuration = grant;
+  }
+
+  risk_category(): RiskCategory {
+    return this.grant_configuration ? "low" : "none";
+  }
+}
+
+export class StoreTemporaryFiles extends SwitchCapability<"store-temporary-files"> {
+  readonly type = "store-temporary-files";
+  readonly title = "Store temporary files";
+  readonly description = `
+    Allow the cartridge to save temporary files in your device's file system.
+    The files will be deleted once the cartridge is closed.
+  `;
+
+  get grant_configuration() {
+    return this._grant_configuration;
+  }
+
+  constructor(readonly cart_id: string, private _grant_configuration: boolean) {
+    super();
+  }
+
+  static parse(grant: CapabilityGrant<StoreTemporaryFiles["type"]>) {
+    if (grant.name !== "store-temporary-files" || grant.granted.type !== "switch") {
+      throw new Error(`Unexpected capability: ${grant.name}`);
+    }
+    return new StoreTemporaryFiles(grant.cart_id, grant.granted.value);
+  }
+
+  static from_metadata(
+    cart_id: string,
+    capability: PassiveCapability & { type: StoreTemporaryFiles["type"] }
+  ) {
+    if (capability.type !== "store-temporary-files") {
+      throw new Error(`Unexpected capability: ${capability.type}`);
+    }
+    return new StoreTemporaryFiles(cart_id, true);
   }
 
   update(grant: boolean): void {

--- a/packages/kate-core/source/capabilities/definitions.ts
+++ b/packages/kate-core/source/capabilities/definitions.ts
@@ -55,8 +55,10 @@ export abstract class StorageSpaceCapability<T extends CapabilityType> extends C
   abstract update(grant: { max_size_bytes: number }): void;
   abstract options: { label: string; bytes: number }[];
 
-  is_allowed(configuration: { max_size_bytes: number }): boolean {
-    return this.grant_configuration.max_size_bytes >= configuration.max_size_bytes;
+  is_allowed(configuration: { max_size_bytes?: number }): boolean {
+    return configuration.max_size_bytes == null
+      ? this.grant_configuration.max_size_bytes > 0
+      : this.grant_configuration.max_size_bytes >= configuration.max_size_bytes;
   }
 
   serialise(): SerialisedCapability {

--- a/packages/kate-core/source/capabilities/serialisation.ts
+++ b/packages/kate-core/source/capabilities/serialisation.ts
@@ -18,7 +18,15 @@ import {
   StoreTemporaryFiles,
 } from "./definitions";
 
-export function parse(grant: AnyCapabilityGrant) {
+export type ParsedCapability = ReturnType<typeof do_parse>;
+
+export function parse<K extends CapabilityType>(
+  grant: AnyCapabilityGrant
+): Extract<ParsedCapability, { type: K }> {
+  return do_parse(grant) as any;
+}
+
+function do_parse(grant: AnyCapabilityGrant) {
   switch (grant.name) {
     case "open-urls": {
       return OpenURLs.parse(grant as CapabilityGrant<"open-urls">);

--- a/packages/kate-core/source/cart/cart-type.ts
+++ b/packages/kate-core/source/cart/cart-type.ts
@@ -145,6 +145,12 @@ export type ContextualCapabilityGrant = {
   reason: string;
 };
 
+export type PassiveCapabilityGrant = {
+  capability: PassiveCapability;
+  reason: string;
+  optional: boolean;
+};
+
 export type ContextualCapability =
   | { type: "open-urls" }
   | { type: "request-device-files" }
@@ -152,8 +158,11 @@ export type ContextualCapability =
   | { type: "download-files" }
   | { type: "show-dialogs" };
 
+export type PassiveCapability = { type: "store-temporary-files"; max_size_mb: number };
+
 export type Security = {
   contextual_capabilities: ContextualCapabilityGrant[];
+  passive_capabilities: PassiveCapabilityGrant[];
 };
 
 export type CartMeta = {

--- a/packages/kate-core/source/data/capability.ts
+++ b/packages/kate-core/source/data/capability.ts
@@ -9,7 +9,9 @@ import { kate } from "./db";
 import * as Capability from "../capabilities";
 import { ContextualCapability, PassiveCapability } from "../cart";
 
-export type GrantType = { type: "switch"; value: boolean };
+export type GrantType =
+  | { type: "switch"; value: boolean }
+  | { type: "storage-space"; value: { max_size_bytes: number } };
 
 type ValidateGrantConfig<T extends Record<CapabilityType, {}>> = T;
 
@@ -20,7 +22,7 @@ export type GrantConfiguration = ValidateGrantConfig<{
   "download-files": {};
   "show-dialogs": {};
   "store-temporary-files": {
-    max_size_mb: number;
+    max_size_bytes: number;
   };
 }>;
 
@@ -91,12 +93,12 @@ export class CapabilityStore {
     return grants.map(Capability.parse);
   }
 
-  async read_grant(cart_id: string, name: CapabilityType) {
+  async read_grant<K extends CapabilityType>(cart_id: string, name: K) {
     const grant = await this.grants.try_get([cart_id, name]);
     if (grant == null) {
       return null;
     } else {
-      return Capability.parse(grant);
+      return Capability.parse<K>(grant);
     }
   }
 

--- a/packages/kate-core/source/data/capability.ts
+++ b/packages/kate-core/source/data/capability.ts
@@ -7,7 +7,7 @@
 import { Database, Transaction } from "../db-schema";
 import { kate } from "./db";
 import * as Capability from "../capabilities";
-import { ContextualCapability } from "../cart";
+import { ContextualCapability, PassiveCapability } from "../cart";
 
 export type GrantType = { type: "switch"; value: boolean };
 
@@ -19,9 +19,12 @@ export type GrantConfiguration = ValidateGrantConfig<{
   "install-cartridges": {};
   "download-files": {};
   "show-dialogs": {};
+  "store-temporary-files": {
+    max_size_mb: number;
+  };
 }>;
 
-export type CapabilityType = ContextualCapability["type"];
+export type CapabilityType = ContextualCapability["type"] | PassiveCapability["type"];
 
 export type SerialisedCapability = Pick<AnyCapabilityGrant, "cart_id" | "name" | "granted">;
 

--- a/packages/kate-core/source/data/db.ts
+++ b/packages/kate-core/source/data/db.ts
@@ -6,4 +6,4 @@
 
 import * as Db from "../db-schema";
 
-export const kate = new Db.DatabaseSchema("kate", 16);
+export const kate = new Db.DatabaseSchema("kate", 17);

--- a/packages/kate-core/source/data/migrations/index.ts
+++ b/packages/kate-core/source/data/migrations/index.ts
@@ -7,3 +7,4 @@
 import "./deprecated";
 import "./v15";
 import "./v16";
+import "./v17";

--- a/packages/kate-core/source/data/migrations/v17.ts
+++ b/packages/kate-core/source/data/migrations/v17.ts
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { cart_meta_v3 } from "../cartridge";
+import { kate } from "../db";
+
+kate.data_migration({
+  id: "v17/cap-format",
+  description: "Capability format change",
+  since: 17,
+  async process(db, os0) {
+    await db.transaction([cart_meta_v3], "readwrite", async (txn) => {
+      const cart = txn.get_table1(cart_meta_v3);
+      for (const x of await cart.get_all()) {
+        if (x.security.passive_capabilities == null) {
+          x.security.passive_capabilities = [];
+          cart.put(x);
+          console.debug(`[db:migration] Patched ${x.id} capability metadata`);
+        }
+      }
+    });
+  },
+});

--- a/packages/kate-core/source/kernel/resource.ts
+++ b/packages/kate-core/source/kernel/resource.ts
@@ -4,7 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-export type Resource = "screen-recording" | "transient-storage" | "low-storage" | "gc";
+export type Resource =
+  | "screen-recording"
+  | "transient-storage"
+  | "low-storage"
+  | "gc"
+  | "temporary-file";
+
 export type RunningProcessMeta = {
   application_id: string;
   trusted: boolean;

--- a/packages/kate-core/source/os/apis/file-store.ts
+++ b/packages/kate-core/source/os/apis/file-store.ts
@@ -342,6 +342,10 @@ export class KateFile {
     return await handle.getFile();
   }
 
+  async get_handle() {
+    return await this.bucket.handle.getFileHandle(this.id, { create: false });
+  }
+
   async delete() {
     await this.bucket.handle.removeEntry(this.id);
     console.debug(`[kate:file-store] Deleted ${this.id}`);

--- a/packages/kate-core/source/os/apis/file-store.ts
+++ b/packages/kate-core/source/os/apis/file-store.ts
@@ -11,8 +11,8 @@
 import { iterate_stream, lock, make_id, sleep, unreachable } from "../../utils";
 import type { KateOS } from "../os";
 
-type PartitionId = "temporary" | "cartridge" | "kernel";
-type BucketId = string & { __bucket_id: true };
+export type PartitionId = "temporary" | "cartridge" | "kernel";
+export type BucketId = string & { __bucket_id: true };
 type BucketRefs = Map<BucketId, Set<WeakRef<KateFileBucket>>>;
 type KernelResource = "media";
 
@@ -328,6 +328,13 @@ export class KateFile {
 
   get path() {
     return `${this.bucket.path}/${this.id}`;
+  }
+
+  async append(data: Uint8Array) {
+    const handle = await this.bucket.handle.getFileHandle(this.id);
+    const writer = await handle.createWritable({ keepExistingData: true });
+    await writer.write(data);
+    await writer.close();
   }
 
   async read() {

--- a/packages/kate-core/source/os/ipc/cart-manager.ts
+++ b/packages/kate-core/source/os/ipc/cart-manager.ts
@@ -8,42 +8,60 @@ import { TC } from "../../utils";
 import { EMessageFailed, auth_handler, handler } from "./handlers";
 import * as Cart from "../../cart";
 import * as UI from "../ui";
+import type { BucketId, PartitionId } from "../apis";
+import type { KateOS } from "../os";
+import type { Process } from "../../kernel";
+
+export async function install(os: KateOS, process: Process, file: Blob) {
+  return await os.fairness_supervisor.with_resource(process, "modal-dialog", async () => {
+    if (os.kernel.console.options.mode === "single") {
+      throw new EMessageFailed("kate.os.not-available", "Feature not available in single mode");
+    }
+
+    let cart;
+    try {
+      cart = await Cart.parse_metadata(file, os.kernel.version);
+    } catch (e) {
+      throw new EMessageFailed("kate.cart-manager.corrupted", "Corrupted cartridge");
+    }
+
+    const should_install = await os.dialog.confirm("kate:cart-manager", {
+      title: "Install cartridge?",
+      message: UI.stack([
+        UI.paragraph([
+          UI.strong([UI.mono_text([process.cartridge.id])]),
+          " wants to install a cartridge:",
+          UI.cartridge_chip(cart),
+        ]),
+      ]),
+    });
+    if (!should_install) {
+      return null;
+    }
+    await os.cart_manager.install_from_file(file);
+    return null;
+  });
+}
 
 export default [
   auth_handler(
-    "kate:cart-manager.install",
+    "kate:cart-manager.install-from-file",
+    TC.spec({ bucket_id: TC.str, file_id: TC.str }),
+    { capabilities: [{ type: "install-cartridges" }] },
+    async (os, process, ipc, { bucket_id, file_id }) => {
+      const bucket_ref = await os.process_file_supervisor.get_ref(process.id, bucket_id);
+      const kate_file = bucket_ref.bucket.file(file_id);
+      const file = await kate_file.read();
+      await install(os, process, file);
+    }
+  ),
+
+  auth_handler(
+    "kate:cart-manager.install-from-bytes",
     TC.spec({ cartridge: TC.bytearray }),
     { capabilities: [{ type: "install-cartridges" }] },
     async (os, process, ipc, { cartridge }) => {
-      return await os.fairness_supervisor.with_resource(process, "modal-dialog", async () => {
-        if (os.kernel.console.options.mode === "single") {
-          throw new EMessageFailed("kate.os.not-available", "Feature not available in single mode");
-        }
-
-        const file = new Blob([cartridge]);
-        let cart;
-        try {
-          cart = await Cart.parse_metadata(file, os.kernel.version);
-        } catch (e) {
-          throw new EMessageFailed("kate.cart-manager.corrupted", "Corrupted cartridge");
-        }
-
-        const should_install = await os.dialog.confirm("kate:cart-manager", {
-          title: "Install cartridge?",
-          message: UI.stack([
-            UI.paragraph([
-              UI.strong([UI.mono_text([process.cartridge.id])]),
-              " wants to install a cartridge:",
-              UI.cartridge_chip(cart),
-            ]),
-          ]),
-        });
-        if (!should_install) {
-          return null;
-        }
-        await os.cart_manager.install_from_file(file);
-        return null;
-      });
+      await install(os, process, new Blob([cartridge]));
     }
   ),
 ];

--- a/packages/kate-core/source/os/ipc/file-storage.ts
+++ b/packages/kate-core/source/os/ipc/file-storage.ts
@@ -5,7 +5,7 @@
  */
 
 import { TC } from "../../utils";
-import { auth_handler } from "./handlers";
+import { WithTransfer, auth_handler } from "./handlers";
 
 export default [
   auth_handler(
@@ -67,9 +67,10 @@ export default [
     { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id, file_id, offset, size }) => {
       const file = await os.process_file_supervisor.read_file(process.id, bucket_id, file_id);
-      return new Uint8Array(
-        await file.slice(offset, size == null ? undefined : offset + size).arrayBuffer()
-      );
+      const buffer = await file
+        .slice(offset, size == null ? undefined : offset + size)
+        .arrayBuffer();
+      return new WithTransfer(new Uint8Array(buffer), [buffer]);
     }
   ),
 

--- a/packages/kate-core/source/os/ipc/file-storage.ts
+++ b/packages/kate-core/source/os/ipc/file-storage.ts
@@ -1,0 +1,80 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { TC } from "../../utils";
+import { handler } from "./handlers";
+
+export const public_repr = {};
+
+export default [
+  handler(
+    "kate:file-store.make-temporary-bucket",
+    TC.spec({ size: TC.int }),
+    async (os, process, ipc, { size }) => {
+      return await os.process_file_supervisor.make_temporary(process.id, size);
+    }
+  ),
+
+  handler(
+    "kate.file-store.delete-bucket",
+    TC.spec({ bucket_id: TC.str }),
+    async (os, process, ipc, { bucket_id }) => {
+      await os.process_file_supervisor.release(process.id, bucket_id);
+      return null;
+    }
+  ),
+
+  handler(
+    "kate:file-store.put-file",
+    TC.spec({ bucket_id: TC.str, data: TC.bytearray }),
+    async (os, process, ipc, { bucket_id, data }) => {
+      return await os.process_file_supervisor.put_file(process.id, bucket_id, data);
+    }
+  ),
+
+  handler(
+    "kate:file-store.append-file",
+    TC.spec({ bucket_id: TC.str, file_id: TC.str, data: TC.bytearray }),
+    async (os, process, ipc, { bucket_id, file_id, data }) => {
+      await os.process_file_supervisor.append_file(process.id, bucket_id, file_id, data);
+      return null;
+    }
+  ),
+
+  handler(
+    "kate:file-store.file-size",
+    TC.spec({ bucket_id: TC.str, file_id: TC.str }),
+    async (os, process, ipc, { bucket_id, file_id }) => {
+      const file = await os.process_file_supervisor.read_file(process.id, bucket_id, file_id);
+      return file.size;
+    }
+  ),
+
+  handler(
+    "kate:file-store.read-file",
+    TC.spec({
+      bucket_id: TC.str,
+      file_id: TC.str,
+      offset: TC.int,
+      size: TC.optional(null, TC.int),
+    }),
+    async (os, process, ipc, { bucket_id, file_id, offset, size }) => {
+      const file = await os.process_file_supervisor.read_file(process.id, bucket_id, file_id);
+      return new Uint8Array(
+        await file.slice(offset, size == null ? undefined : offset + size).arrayBuffer()
+      );
+    }
+  ),
+
+  handler(
+    "kate:file-store.delete-file",
+    TC.spec({ bucket_id: TC.str, file_id: TC.str }),
+    async (os, process, ipc, { bucket_id, file_id }) => {
+      await os.process_file_supervisor.delete_file(process.id, bucket_id, file_id);
+      return null;
+    }
+  ),
+];

--- a/packages/kate-core/source/os/ipc/file-storage.ts
+++ b/packages/kate-core/source/os/ipc/file-storage.ts
@@ -5,55 +5,60 @@
  */
 
 import { TC } from "../../utils";
-import { handler } from "./handlers";
+import { auth_handler, handler } from "./handlers";
 
 export const public_repr = {};
 
 export default [
-  handler(
+  auth_handler(
     "kate:file-store.make-temporary-bucket",
     TC.spec({ size: TC.int }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { size }) => {
       return await os.process_file_supervisor.make_temporary(process.id, size);
     }
   ),
 
-  handler(
+  auth_handler(
     "kate.file-store.delete-bucket",
     TC.spec({ bucket_id: TC.str }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id }) => {
       await os.process_file_supervisor.release(process.id, bucket_id);
       return null;
     }
   ),
 
-  handler(
+  auth_handler(
     "kate:file-store.put-file",
     TC.spec({ bucket_id: TC.str, data: TC.bytearray }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id, data }) => {
       return await os.process_file_supervisor.put_file(process.id, bucket_id, data);
     }
   ),
 
-  handler(
+  auth_handler(
     "kate:file-store.append-file",
     TC.spec({ bucket_id: TC.str, file_id: TC.str, data: TC.bytearray }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id, file_id, data }) => {
       await os.process_file_supervisor.append_file(process.id, bucket_id, file_id, data);
       return null;
     }
   ),
 
-  handler(
+  auth_handler(
     "kate:file-store.file-size",
     TC.spec({ bucket_id: TC.str, file_id: TC.str }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id, file_id }) => {
       const file = await os.process_file_supervisor.read_file(process.id, bucket_id, file_id);
       return file.size;
     }
   ),
 
-  handler(
+  auth_handler(
     "kate:file-store.read-file",
     TC.spec({
       bucket_id: TC.str,
@@ -61,6 +66,7 @@ export default [
       offset: TC.int,
       size: TC.optional(null, TC.int),
     }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id, file_id, offset, size }) => {
       const file = await os.process_file_supervisor.read_file(process.id, bucket_id, file_id);
       return new Uint8Array(
@@ -69,9 +75,10 @@ export default [
     }
   ),
 
-  handler(
+  auth_handler(
     "kate:file-store.delete-file",
     TC.spec({ bucket_id: TC.str, file_id: TC.str }),
+    { capabilities: [{ type: "store-temporary-files" }] },
     async (os, process, ipc, { bucket_id, file_id }) => {
       await os.process_file_supervisor.delete_file(process.id, bucket_id, file_id);
       return null;

--- a/packages/kate-core/source/os/ipc/ipc.ts
+++ b/packages/kate-core/source/os/ipc/ipc.ts
@@ -16,6 +16,7 @@ import BrowserMessages from "./browser";
 import DeviceFileMessages from "./device-file";
 import CartManagerMessages from "./cart-manager";
 import DialogMessages from "./dialog";
+import FileStorage from "./file-storage";
 import { Process, SystemEvent } from "../../kernel";
 
 type Message = {
@@ -40,6 +41,7 @@ export class KateIPCServer {
     this.add_handlers(DeviceFileMessages);
     this.add_handlers(CartManagerMessages);
     this.add_handlers(DialogMessages);
+    this.add_handlers(FileStorage);
   }
 
   private add_handlers(handlers: Handler<any, any>[]) {

--- a/packages/kate-core/source/os/os.ts
+++ b/packages/kate-core/source/os/os.ts
@@ -35,6 +35,7 @@ import { KateAuditSupervisor } from "./services/audit-supervisor";
 import { KateDeviceFile } from "./apis/device-file";
 import { KateFairnessSupervisor } from "./services/fairness-supervisor";
 import { ButtonChangeEvent } from "../kernel";
+import { KateProcessFileSupervisor } from "./services/process-file-supervisor";
 
 export type CartChangeReason = "installed" | "removed" | "archived" | "save-data-changed";
 
@@ -65,6 +66,7 @@ export class KateOS {
   readonly capability_supervisor: KateCapabilitySupervisor;
   readonly audit_supervisor: KateAuditSupervisor;
   readonly fairness_supervisor: KateFairnessSupervisor;
+  readonly process_file_supervisor: KateProcessFileSupervisor;
   readonly TRACE_ENABLED = trace_messages;
 
   readonly events = {
@@ -111,6 +113,8 @@ export class KateOS {
     this.audit_supervisor = new KateAuditSupervisor(this);
     this.fairness_supervisor = new KateFairnessSupervisor(this);
     this.file_store = new KateFileStore(this);
+    this.process_file_supervisor = new KateProcessFileSupervisor(this);
+    this.process_file_supervisor.setup();
   }
 
   get display() {

--- a/packages/kate-core/source/os/services/capability-supervisor.ts
+++ b/packages/kate-core/source/os/services/capability-supervisor.ts
@@ -17,6 +17,17 @@ export class KateCapabilitySupervisor {
     );
   }
 
+  async try_get_grant<K extends CapabilityType>(cart_id: string, capability: K) {
+    return await CapabilityStore.transaction(
+      this.os.db,
+      "capability",
+      "readonly",
+      async (store) => {
+        return store.read_grant(cart_id, capability);
+      }
+    );
+  }
+
   async update_grant(cart_id: string, grant: AnyCapability) {
     return await CapabilityStore.transaction(
       this.os.db,
@@ -38,13 +49,13 @@ export class KateCapabilitySupervisor {
       "capability",
       "readonly",
       async (store) => {
-        return store.read_grant(cart_id, capability);
+        return store.read_grant<T>(cart_id, capability);
       }
     );
     if (grant == null) {
       return false;
     } else {
-      return grant.is_allowed(configuration);
+      return grant.is_allowed(configuration as any);
     }
   }
 }

--- a/packages/kate-core/source/os/services/capability-supervisor.ts
+++ b/packages/kate-core/source/os/services/capability-supervisor.ts
@@ -6,6 +6,7 @@
 
 import { AnyCapability, Capability } from "../../capabilities";
 import { CapabilityStore, CapabilityType, GrantConfiguration } from "../../data/capability";
+import { OptionalRec } from "../../utils";
 import type { KateOS } from "../os";
 
 export class KateCapabilitySupervisor {
@@ -42,7 +43,7 @@ export class KateCapabilitySupervisor {
   async is_allowed<T extends CapabilityType>(
     cart_id: string,
     capability: T,
-    configuration: GrantConfiguration[T]
+    configuration: OptionalRec<GrantConfiguration[T]>
   ) {
     const grant = await CapabilityStore.transaction(
       this.os.db,
@@ -55,7 +56,7 @@ export class KateCapabilitySupervisor {
     if (grant == null) {
       return false;
     } else {
-      return grant.is_allowed(configuration as any);
+      return grant.is_allowed(configuration);
     }
   }
 }

--- a/packages/kate-core/source/os/services/process-file-supervisor.ts
+++ b/packages/kate-core/source/os/services/process-file-supervisor.ts
@@ -1,0 +1,132 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type { ProcessId, SystemEvent } from "../../kernel";
+import { from_bytes, make_id } from "../../utils";
+import { BucketId, KateFileBucket, PartitionId } from "../apis";
+import type { KateOS } from "../os";
+
+type Bucket = {
+  bucket: KateFileBucket;
+  id: string;
+  size: number;
+  max_size: number;
+};
+
+export class KateProcessFileSupervisor {
+  readonly PROCESS_MAX = 8 * 1024 * 1024 * 1024; // 8gb
+  private _started = false;
+  private resources = new Map<ProcessId, Map<string, Bucket>>();
+  constructor(readonly os: KateOS) {}
+
+  setup() {
+    if (this._started) {
+      throw new Error(`[kate:process-file-supervisor] setup() called twice`);
+    }
+    this.os.kernel.processes.on_system_event.listen(this.handle_process_event);
+  }
+
+  handle_process_event = (ev: SystemEvent) => {
+    if (ev.type === "killed") {
+      const refs = this.get_refs(ev.process.id);
+      if (refs.size > 0) {
+        console.debug(`[kate:process-file-supervisor] Releasing buckets held by ${ev.process.id}`);
+        this.resources.delete(ev.process.id);
+      }
+    }
+  };
+
+  get_refs(process: ProcessId) {
+    return this.resources.get(process) ?? new Map<string, Bucket>();
+  }
+
+  current_size(process: ProcessId) {
+    const refs = this.get_refs(process);
+    let result = 0;
+    for (const ref of refs.values()) {
+      result += ref.max_size;
+    }
+    return result;
+  }
+
+  get_ref(process: ProcessId, id: string) {
+    const refs = this.get_refs(process);
+    const ref = refs.get(id);
+    if (ref == null) {
+      throw new Error(
+        `[kate:process-file-supervisor] Invalid bucket reference ${id} for process ${process}`
+      );
+    }
+    return ref;
+  }
+
+  async make_temporary(process: ProcessId, size: number) {
+    if (this.current_size(process) + size > this.PROCESS_MAX) {
+      throw new Error(
+        `[kate:process-file-supervisor] ${process} buckets would use more space than allowed.`
+      );
+    }
+
+    const partition = await this.os.file_store.get_partition("temporary");
+    const bucket = await partition.create(null);
+    const id = make_id();
+    const refs = this.get_refs(process);
+    refs.set(id, { bucket: bucket, id, size: 0, max_size: size });
+    this.resources.set(process, refs);
+    return id;
+  }
+
+  async release(process: ProcessId, id: string) {
+    const refs = this.get_refs(process);
+    if (refs.has(id)) {
+      refs.delete(id);
+    } else {
+      console.warn(`[kate:process-file-supervisor] ${process} released unknown bucket ${id}.`);
+    }
+    this.resources.set(process, refs);
+  }
+
+  async put_file(process: ProcessId, id: string, data: Uint8Array) {
+    const ref = this.get_ref(process, id);
+    if (ref.size + data.byteLength > ref.max_size) {
+      throw new Error(
+        `[kate:process-file-supervisor] ${process} failed to store file in ${id}: max size (${from_bytes(
+          ref.max_size
+        )}) for the bucket exceeded`
+      );
+    }
+    const file = await ref.bucket.put(data);
+    ref.size += data.byteLength;
+    return file.id;
+  }
+
+  async append_file(process: ProcessId, id: string, file_id: string, data: Uint8Array) {
+    const ref = this.get_ref(process, id);
+    if (ref.size + data.byteLength > ref.max_size) {
+      throw new Error(
+        `[kate:process-file-supervisor] ${process} failed to store file in ${id}: max size (${from_bytes(
+          ref.max_size
+        )}) for the bucket exceeded`
+      );
+    }
+    await ref.bucket.file(file_id).append(data);
+    ref.size += data.byteLength;
+  }
+
+  async read_file(process: ProcessId, id: string, file_id: string) {
+    const ref = this.get_ref(process, id);
+    const file = await ref.bucket.file(file_id).read();
+    return file;
+  }
+
+  async delete_file(process: ProcessId, id: string, file_id: string) {
+    const ref = this.get_ref(process, id);
+    const file = ref.bucket.file(file_id);
+    const handle = await file.read();
+    ref.size -= handle.size;
+    await file.delete();
+  }
+}

--- a/packages/kate-core/source/utils.ts
+++ b/packages/kate-core/source/utils.ts
@@ -26,3 +26,5 @@ export * from "../../util/build/semver";
 export function lock<T>(name: string, fn: () => Promise<T>): Promise<T> {
   return navigator.locks.request(name, fn);
 }
+
+export type OptionalRec<T> = T extends {} ? { [k in keyof T]?: OptionalRec<T[k]> } : T;

--- a/packages/kate-tools/source/kart-show.ts
+++ b/packages/kate-tools/source/kart-show.ts
@@ -271,6 +271,15 @@ function show_capability(x: Cart.Capability) {
       console.log(`    > Reason: ${x.reason}\n`);
       break;
     }
+
+    case t.$Tags.Passive: {
+      show_passive_capability(x.capability, x.optional);
+      console.log(`    > Reason: ${x.reason}\n`);
+      break;
+    }
+
+    default:
+      throw unreachable(x);
   }
 }
 
@@ -304,6 +313,19 @@ function show_contextual_capability(x: Cart.Contextual_capability) {
 
     default:
       throw unreachable(x);
+  }
+}
+
+function show_passive_capability(x: Cart.Passive_capability, optional: boolean) {
+  const t = Cart.Passive_capability;
+  switch (x["@variant"]) {
+    case t.$Tags.Store_temporary_files: {
+      console.log(`  * Store temporary files (max ${from_bytes(x["max-size-mb"] * 1024 * 1024)})`);
+      break;
+    }
+
+    // default:
+    //   throw unreachable(x);
   }
 }
 

--- a/packages/kate-tools/source/kart.ts
+++ b/packages/kate-tools/source/kart.ts
@@ -254,6 +254,12 @@ const capability = T.tagged_choice<Capability, Capability["type"]>("type", {
     type: T.constant("show-dialogs" as const),
     reason: T.short_str(255),
   }),
+  "store-temporary-files": T.spec({
+    type: T.constant("store-temporary-files" as const),
+    reason: T.short_str(255),
+    max_size_mb: T.int,
+    optional: T.bool,
+  }),
 });
 
 const security = T.spec({
@@ -362,7 +368,8 @@ type ContextualCapability =
   | { type: "request-device-files" }
   | { type: "install-cartridges" }
   | { type: "download-files" }
-  | { type: "show-dialogs" };
+  | { type: "show-dialogs" }
+  | { type: "store-temporary-files"; max_size_mb: number; optional: boolean };
 
 type Bridge =
   | { type: "network-proxy" }
@@ -769,6 +776,16 @@ function make_capability(json: Capability) {
     case "show-dialogs": {
       return Cart.Capability.Contextual({
         capability: Cart.Contextual_capability.Show_dialogs({}),
+        reason: json.reason,
+      });
+    }
+
+    case "store-temporary-files": {
+      return Cart.Capability.Passive({
+        capability: Cart.Passive_capability.Store_temporary_files({
+          "max-size-mb": json.max_size_mb,
+        }),
+        optional: json.optional,
         reason: json.reason,
       });
     }

--- a/packages/schema/schemas/kart-v6.ljt
+++ b/packages/schema/schemas/kart-v6.ljt
@@ -248,6 +248,11 @@ union Capability {
     field capability: Contextual-capability;
     field reason: Text;
   }
+  type Passive {
+    field capability: Passive-capability;
+    field optional: Boolean;
+    field reason: Text;
+  }
 }
 
 union Contextual-capability {
@@ -265,6 +270,13 @@ union Contextual-capability {
 
   // low risk: annoyance, denial-of-service
   type Show-dialogs {}
+}
+
+union Passive-capability {
+  // low risk: storage degradation
+  type Store-temporary-files {
+    field max-size-mb: Uint32;
+  }
 }
 
 union Keyboard-input-selector {

--- a/packages/schema/source/generated/kart-v6.json
+++ b/packages/schema/source/generated/kart-v6.json
@@ -433,7 +433,7 @@
               "name": "hash-algorithm",
               "type": {
                 "op": "union",
-                "id": 28
+                "id": 29
               }
             },
             {
@@ -960,7 +960,7 @@
                   "name": "selector",
                   "type": {
                     "op": "union",
-                    "id": 27
+                    "id": 28
                   }
                 }
               ]
@@ -1069,6 +1069,30 @@
                   }
                 }
               ]
+            },
+            {
+              "name": "Passive",
+              "fields": [
+                {
+                  "name": "capability",
+                  "type": {
+                    "op": "union",
+                    "id": 27
+                  }
+                },
+                {
+                  "name": "optional",
+                  "type": {
+                    "op": "bool"
+                  }
+                },
+                {
+                  "name": "reason",
+                  "type": {
+                    "op": "text"
+                  }
+                }
+              ]
             }
           ]
         }
@@ -1107,8 +1131,30 @@
     },
     {
       "type": "union",
-      "name": "Keyboard-input-selector",
+      "name": "Passive-capability",
       "id": 27,
+      "versions": [
+        {
+          "variants": [
+            {
+              "name": "Store-temporary-files",
+              "fields": [
+                {
+                  "name": "max-size-mb",
+                  "type": {
+                    "op": "uint32"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "union",
+      "name": "Keyboard-input-selector",
+      "id": 28,
       "versions": [
         {
           "variants": [
@@ -1142,7 +1188,7 @@
     {
       "type": "union",
       "name": "Hash-algorithm",
-      "id": 28,
+      "id": 29,
       "versions": [
         {
           "variants": [

--- a/packages/schema/source/generated/kart-v6.ts
+++ b/packages/schema/source/generated/kart-v6.ts
@@ -1925,13 +1925,14 @@ Keyboard_key.tag = 24;
 
 
 
-export type Capability = Capability.Contextual;
+export type Capability = Capability.Contextual | Capability.Passive;
 
 export namespace Capability {
  export const tag = 25;
 
  export const enum $Tags {
-   Contextual = 0
+   Contextual = 0,
+    Passive = 1
  }
 
  
@@ -1953,6 +1954,30 @@ export namespace Capability {
    readonly '@variant': $Tags.Contextual;
    readonly '@variant-name': 'Contextual';
    readonly 'capability': Contextual_capability
+    readonly 'reason': string
+ }
+
+
+  
+ export function Passive(x: {readonly 'capability': Passive_capability,readonly 'optional': boolean,readonly 'reason': string}): Capability {
+   return {
+     '@name': 'Capability',
+     '@tag': 25,
+     '@version': 0,
+     '@variant': $Tags.Passive,
+     '@variant-name': 'Passive',
+     ...x
+   }
+ }
+
+ export interface Passive {
+   readonly '@name': 'Capability';
+   readonly '@tag': 25;
+   readonly '@version': 0;
+   readonly '@variant': $Tags.Passive;
+   readonly '@variant-name': 'Passive';
+   readonly 'capability': Passive_capability
+    readonly 'optional': boolean
     readonly 'reason': string
  }
 
@@ -2086,10 +2111,44 @@ export namespace Contextual_capability {
 
 
 
+export type Passive_capability = Passive_capability.Store_temporary_files;
+
+export namespace Passive_capability {
+ export const tag = 27;
+
+ export const enum $Tags {
+   Store_temporary_files = 0
+ }
+
+ 
+ export function Store_temporary_files(x: {readonly 'max-size-mb': UInt32}): Passive_capability {
+   return {
+     '@name': 'Passive-capability',
+     '@tag': 27,
+     '@version': 0,
+     '@variant': $Tags.Store_temporary_files,
+     '@variant-name': 'Store-temporary-files',
+     ...x
+   }
+ }
+
+ export interface Store_temporary_files {
+   readonly '@name': 'Passive-capability';
+   readonly '@tag': 27;
+   readonly '@version': 0;
+   readonly '@variant': $Tags.Store_temporary_files;
+   readonly '@variant-name': 'Store-temporary-files';
+   readonly 'max-size-mb': UInt32
+ }
+
+}
+
+
+
 export type Keyboard_input_selector = Keyboard_input_selector.Window | Keyboard_input_selector.Document | Keyboard_input_selector.Legacy | Keyboard_input_selector.CSS;
 
 export namespace Keyboard_input_selector {
- export const tag = 27;
+ export const tag = 28;
 
  export const enum $Tags {
    Window = 0,
@@ -2102,7 +2161,7 @@ export namespace Keyboard_input_selector {
  export function Window(x: {}): Keyboard_input_selector {
    return {
      '@name': 'Keyboard-input-selector',
-     '@tag': 27,
+     '@tag': 28,
      '@version': 0,
      '@variant': $Tags.Window,
      '@variant-name': 'Window',
@@ -2112,7 +2171,7 @@ export namespace Keyboard_input_selector {
 
  export interface Window {
    readonly '@name': 'Keyboard-input-selector';
-   readonly '@tag': 27;
+   readonly '@tag': 28;
    readonly '@version': 0;
    readonly '@variant': $Tags.Window;
    readonly '@variant-name': 'Window';
@@ -2124,7 +2183,7 @@ export namespace Keyboard_input_selector {
  export function Document(x: {}): Keyboard_input_selector {
    return {
      '@name': 'Keyboard-input-selector',
-     '@tag': 27,
+     '@tag': 28,
      '@version': 0,
      '@variant': $Tags.Document,
      '@variant-name': 'Document',
@@ -2134,7 +2193,7 @@ export namespace Keyboard_input_selector {
 
  export interface Document {
    readonly '@name': 'Keyboard-input-selector';
-   readonly '@tag': 27;
+   readonly '@tag': 28;
    readonly '@version': 0;
    readonly '@variant': $Tags.Document;
    readonly '@variant-name': 'Document';
@@ -2146,7 +2205,7 @@ export namespace Keyboard_input_selector {
  export function Legacy(x: {}): Keyboard_input_selector {
    return {
      '@name': 'Keyboard-input-selector',
-     '@tag': 27,
+     '@tag': 28,
      '@version': 0,
      '@variant': $Tags.Legacy,
      '@variant-name': 'Legacy',
@@ -2156,7 +2215,7 @@ export namespace Keyboard_input_selector {
 
  export interface Legacy {
    readonly '@name': 'Keyboard-input-selector';
-   readonly '@tag': 27;
+   readonly '@tag': 28;
    readonly '@version': 0;
    readonly '@variant': $Tags.Legacy;
    readonly '@variant-name': 'Legacy';
@@ -2168,7 +2227,7 @@ export namespace Keyboard_input_selector {
  export function CSS(x: {readonly 'selector': string}): Keyboard_input_selector {
    return {
      '@name': 'Keyboard-input-selector',
-     '@tag': 27,
+     '@tag': 28,
      '@version': 0,
      '@variant': $Tags.CSS,
      '@variant-name': 'CSS',
@@ -2178,7 +2237,7 @@ export namespace Keyboard_input_selector {
 
  export interface CSS {
    readonly '@name': 'Keyboard-input-selector';
-   readonly '@tag': 27;
+   readonly '@tag': 28;
    readonly '@version': 0;
    readonly '@variant': $Tags.CSS;
    readonly '@variant-name': 'CSS';
@@ -2192,7 +2251,7 @@ export namespace Keyboard_input_selector {
 export type Hash_algorithm = Hash_algorithm.Sha_512;
 
 export namespace Hash_algorithm {
- export const tag = 28;
+ export const tag = 29;
 
  export const enum $Tags {
    Sha_512 = 0
@@ -2202,7 +2261,7 @@ export namespace Hash_algorithm {
  export function Sha_512(x: {}): Hash_algorithm {
    return {
      '@name': 'Hash-algorithm',
-     '@tag': 28,
+     '@tag': 29,
      '@version': 0,
      '@variant': $Tags.Sha_512,
      '@variant-name': 'Sha-512',
@@ -2212,7 +2271,7 @@ export namespace Hash_algorithm {
 
  export interface Sha_512 {
    readonly '@name': 'Hash-algorithm';
-   readonly '@tag': 28;
+   readonly '@tag': 29;
    readonly '@version': 0;
    readonly '@variant': $Tags.Sha_512;
    readonly '@variant-name': 'Sha-512';

--- a/packages/util/source/unit.ts
+++ b/packages/util/source/unit.ts
@@ -8,7 +8,7 @@ export function mhz_to_ghz(n: number) {
   return `${(n / 1000).toFixed(3)} GHz`;
 }
 
-export function from_bytes(n0: number | bigint) {
+export function from_bytes(n0: number | bigint, decimals: number = 2) {
   const units = [
     ["KB", 1024],
     ["MB", 1024],
@@ -19,7 +19,7 @@ export function from_bytes(n0: number | bigint) {
   let n = Number(n0);
   let use_unit = "B";
   for (const [unit, bucket] of units) {
-    if (n > bucket) {
+    if (n >= bucket) {
       n /= bucket;
       use_unit = unit;
     } else {
@@ -27,7 +27,7 @@ export function from_bytes(n0: number | bigint) {
     }
   }
 
-  return `${n.toFixed(2)} ${use_unit}`;
+  return `${n.toFixed(decimals)} ${use_unit}`;
 }
 
 export function bytes(n: number) {

--- a/www/css/kate.css
+++ b/www/css/kate.css
@@ -163,6 +163,15 @@ body {
   display: block;
 }
 
+.kate-resource-temporary-file {
+  font-family: "Font Awesome 6 Free";
+}
+
+.kate-resource-temporary-file::before {
+  content: "\f15b";
+  display: block;
+}
+
 .kate-resource-transient-storage {
   font-family: "Font Awesome 6 Free";
 }

--- a/www/css/os/ui.css
+++ b/www/css/os/ui.css
@@ -156,6 +156,10 @@
   gap: 0.3rem;
 }
 
+.kate-ui-select-panel .kate-ui-link-card-text {
+  margin-right: 2rem;
+}
+
 .kate-ui-link-card-title,
 .kate-ui-text-panel-title {
   font-weight: 500;
@@ -175,6 +179,7 @@
 
 .kate-ui-link-card-value {
   color: var(--color-text-very-muted);
+  white-space: nowrap;
 }
 
 /* #Toggle */

--- a/www/css/os/ui.css
+++ b/www/css/os/ui.css
@@ -86,6 +86,7 @@
 
 .kate-ui-info-line-label {
   font-weight: 500;
+  margin-right: 2rem;
 }
 
 .kate-ui-info-line-data {


### PR DESCRIPTION
This patch allows processes to store temporary files in buckets up to a configurable size. The new `store-temporary-files` passive capability decides the "maximum amount of storage" configuration for each process, which is otherwise capped at 60% of the available storage.

Importer is now written using the temporary files, which improves its memory usage a little bit.