### PR TITLE
Allow "synchronous" loading of cartridge files

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,11 @@ We aim to support all reasonable web-exports of common game engines. The list be
 - ✔️ **Ren'Py** (full support for Ren'Py web export 7.5 and 8.1 as of Kate v0.23.6);
 - ✔️ **GB Studio** (web emulators work with existing bridges, but no recipe provided yet);
 - ✔️ **Pico-8** (web export works with existing bridges, but no recipe provided yet);
-- ➖ RPG Maker MV (requires minor code changes in the game);
+- ✔️ **Godot 3** (web exports should be fully functional as of Kate v0.25.x);
+- ✔️ **RPG Maker MV** (web exports should be functional as of Kate v0.25.x --- plugin support depends on what APIs the plugin requires);
 - ➖ Unity (requires minor code changes in the game);
 - ✖️ Twine (requires changes to Kate's sandboxing);
-- ✖️ Godot (requires changes to Kate's sandboxing);
+- ✖️ Godot 4 (requires changes to Kate's sandboxing);
 - ✖️ Construct 3 (requires changes to Kate's sandboxing);
 - ✖️ TyranoBuilder (requires changes to Kate's sandboxing);
 

--- a/docs/source/dev/port/bitsy.rst
+++ b/docs/source/dev/port/bitsy.rst
@@ -1,7 +1,7 @@
 Bitsy
 =====
 
-Games made with `Bitsy <https://bitsy.org/>` can run on Kate with little
+Games made with `Bitsy <https://bitsy.org/>`_ can run on Kate with little
 configuration. Games using bitsy hacks might not be supported.
 
 

--- a/docs/source/dev/port/godot.rst
+++ b/docs/source/dev/port/godot.rst
@@ -1,0 +1,87 @@
+Godot
+=====
+
+Games made with `Godot <https://godotengine.org/>`_ can run on Kate when
+using the HTML5 export option.
+
+.. important::
+  Only games exported with Godot 3 are currently supported due to some
+  requirements in games exported with Godot 4 that are disabled until some
+  `outstanding security issues can be addressed <https://github.com/orgs/qteatime/discussions/1>`_.
+
+
+Kart configuration
+------------------
+
+The minimal configuration for a Godot game looks like this:
+
+.. code-block:: json
+
+  {
+    "id": "my-namespace/my-game",
+    "version": {"major": 1, "minor": 0},
+    "metadata": {
+      "presentation": {
+        "author": "Me",
+        "title": "My Game",
+        "tagline": "A godot game"
+      }
+    },
+    "platform": {
+      "type": "web-archive",
+      "html": "my_game.html",
+      "recipe": {
+        "type": "godot",
+        "version": "3",
+        "pointer_support": true,
+        "hide_cursor": false
+      }
+    }
+  }
+
+This assumes that you've exported your Godot game to a file called ``my_game.html``.
+
+
+Bridges used
+------------
+
+This recipe includes the following bridges:
+
+.. code-block::
+
+  {
+    "bridges": [
+      { "type": "network-proxy", "sync_access": ["*.js"] },
+      { "type": "keyboard-input-proxy-v2", "mapping": "defaults", "selector": "#canvas" },
+      { "type": "pointer-input-proxy", "selector": "#canvas", "hide_cursor": false },
+      { "type": "capture-canvas", "selector": "#canvas" },
+      { "type": "preserve-webgl-render" }
+    ]
+  }
+
+The ``point-input-proxy`` depends on whether you've enabled ``pointer_support``
+in your recipe configuration or not. If your game uses other features and APIs,
+you might need to specify additional bridges in the ``platform`` section,
+as usual; those will take precedence over the default recipe configuration.
+
+
+Included files
+--------------
+
+By default the recipe will include all files that are generated for a
+default Godot project. If you need other files, you'll have to include
+them in the ``files`` section manually.
+
+The default file patterns are:
+
+.. code-block::
+
+  {
+    "files": [
+      "**/*.html",
+      "**/*.png",
+      "**/*.js",
+      "**/*.pck",
+      "**/*.wasm"
+    ]
+  }

--- a/docs/source/dev/port/index.rst
+++ b/docs/source/dev/port/index.rst
@@ -13,3 +13,5 @@ Porting recipes are currently available for the following engines:
 
   bitsy
   renpy
+  godot
+  rpg-maker

--- a/docs/source/dev/port/rpg-maker.rst
+++ b/docs/source/dev/port/rpg-maker.rst
@@ -1,0 +1,108 @@
+RPG Maker MV
+============
+
+Games made with `RPG Maker MV <https://www.rpgmakerweb.com/products/rpg-maker-mv>`_
+can run on Kate when using the web export option.
+
+.. important::
+  The recipe only covers the default RPG Maker MV configuration. If you're
+  using plugins, you'll likely need to specify any additional APIs they
+  require manually.
+
+
+Kart configuration
+------------------
+
+The minimal configuration for a RPG Maker MV game looks like this:
+
+.. code-block:: json
+
+  {
+    "id": "my-namespace/my-game",
+    "root": "www",
+    "version": {"major": 1, "minor": 0},
+    "metadata": {
+      "presentation": {
+        "author": "Me",
+        "title": "My Game",
+        "tagline": "A RPG Maker MV game"
+      }
+    },
+    "platform": {
+      "type": "web-archive",
+      "html": "index.html",
+      "recipe": {
+        "type": "rpg-maker-mv",
+        "pointer_support": true,
+        "hide_cursor": false
+      }
+    }
+  }
+
+This assumes that you're placing your ``kate.json`` configuration outside
+of the ``www`` folder that the export generates.
+
+
+Bridges used
+------------
+
+This recipe includes the following bridges:
+
+.. code-block::
+
+  {
+    "bridges": [
+      { "type": "network-proxy", "sync_access": ["js/plugins/*.js", "img/tilesets/*.png"] },
+      { "type": "keyboard-input-proxy-v2", "mapping": "defaults", "selector": "document" },
+      { "type": "pointer-input-proxy", "selector": "#GameCanvas", "hide_cursor": false },
+      { "type": "capture-canvas", "selector": "#GameCanvas" },
+      { "type": "preserve-webgl-render" },
+      { "type": "local-storage-proxy" }
+    ]
+  }
+
+The ``point-input-proxy`` depends on whether you've enabled ``pointer_support``
+in your recipe configuration or not. If your game uses other features and APIs,
+you might need to specify additional bridges in the ``platform`` section,
+as usual; those will take precedence over the default recipe configuration.
+
+
+Included files
+--------------
+
+By default the recipe will include all files that are generated for a
+default RPG Maker MV project. If you need other files, you'll have to include
+them in the ``files`` section manually.
+
+The default file patterns are:
+
+.. code-block::
+
+  {
+    "files": [
+      "**/*.html",
+      "**/*.json",
+      "**/*.ogg",
+      "**/*.css",
+      "**/*.ttf",
+      "**/*.png",
+      "**/*.txt",
+      "**/*.js"
+    ]
+  }
+
+Note that this does not include the `*.m4a` files which RPG Maker has for
+Apple devices. That would double the size of the cartridge and increase
+significantly the time required to install it. Kate will support decoding
+of OGG sound files on Apple devices in the future natively, so there's no
+need to add proprietary formats.
+
+
+Resolution
+----------
+
+Kate's native resolution is 800x480 on physical devices (and the handheld
+mode in the emulator), this means that ideally you'll have your game fit
+the 800x480 resolution as well. The easiest way of achieving this is to
+enable the ``Community_Basic`` plugin and specify the ``screenWidth`` and
+``screenHeight`` to match Kate's native resolution.

--- a/packages/kate-api/source/index.ts
+++ b/packages/kate-api/source/index.ts
@@ -108,3 +108,5 @@ declare global {
     };
   }
 }
+
+import "./lockdown";

--- a/packages/kate-api/source/lockdown.ts
+++ b/packages/kate-api/source/lockdown.ts
@@ -1,0 +1,19 @@
+const user_agent = "Kate";
+
+Object.defineProperty(navigator, "userAgent", {
+  value: user_agent,
+  enumerable: true,
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: new Proxy(navigator, {
+    has(target, key) {
+      return key !== "serviceWorker" && key in target;
+    },
+    get(target, key) {
+      return key === "serviceWorker" ? undefined : (target as any)[key];
+    },
+  }),
+});

--- a/packages/kate-bridges/source/standard-network.ts
+++ b/packages/kate-bridges/source/standard-network.ts
@@ -23,19 +23,18 @@ void (function () {
     if (is_data_url(url0)) {
       return url0;
     }
-    if (SYNC_ACCESS[url0]) {
-      const data = SYNC_ACCESS[url0];
-      const bytes = new TextEncoder().encode(data);
-      const byte_string = Array.from(bytes, (x) => String.fromCodePoint(x)).join("");
-      return `data:text/plain;base64,${window.btoa(byte_string)}`;
-    }
 
     const url = new URL(url0, "https://cartridge.kate.qteati.me");
     if (url.hostname !== "cartridge.kate.qteati.me") {
       console.warn(`[Kate] Non-proxyable URL:`, url0);
       return url0;
     } else {
-      return decodeURIComponent(url.pathname);
+      const decoded_url = decodeURIComponent(url.pathname);
+      if (SYNC_ACCESS[decoded_url]) {
+        return SYNC_ACCESS[decoded_url];
+      } else {
+        return decoded_url;
+      }
     }
   }
 
@@ -128,9 +127,13 @@ void (function () {
       return this.__src ?? old_img_src.get!.call(this);
     },
     set(url0) {
-      const url = fix_url(url0);
+      if (url0 === "") {
+        old_img_src.set!.call(this, "");
+        return;
+      }
 
-      this.__src = url;
+      this.__src = url0;
+      const url = fix_url(url0);
       if (is_data_url(url)) {
         old_img_src.set!.call(this, url);
         return;
@@ -157,8 +160,8 @@ void (function () {
       return this.__src ?? old_script_src.get!.call(this);
     },
     set(url0) {
+      this.__src = url0;
       const url = fix_url(url0);
-      this.__src = url;
       if (is_data_url(url)) {
         old_script_src.set!.call(this, url);
         return;
@@ -185,9 +188,9 @@ void (function () {
       return this.__src ?? old_media_src.get!.call(this);
     },
     set(url0) {
-      const url = fix_url(url0);
+      this.__src = url0;
 
-      this.__src = url;
+      const url = fix_url(url0);
       if (is_data_url(url)) {
         old_media_src.set!.call(this, url);
         return;

--- a/packages/kate-core/source/cart/cart-type.ts
+++ b/packages/kate-core/source/cart/cart-type.ts
@@ -109,7 +109,8 @@ export type Bridge =
   | { type: "pointer-input-proxy"; selector: string; hide_cursor: boolean }
   | { type: "indexeddb-proxy"; versioned: boolean }
   | { type: "renpy-web-tweaks"; version: { major: number; minor: number } }
-  | { type: "external-url-handler" };
+  | { type: "external-url-handler" }
+  | { type: "network-proxy-v2"; allow_sync_access: string[] };
 
 export type KeyboardKey = {
   key: string;

--- a/packages/kate-core/source/cart/v6/runtime.ts
+++ b/packages/kate-core/source/cart/v6/runtime.ts
@@ -68,6 +68,15 @@ function bridge(x: Cart_v6.Bridge): Bridge {
         selector: keyboard_selector(x.selector),
       };
     }
+    case Cart_v6.Bridge.$Tags.Network_proxy_v2: {
+      return {
+        type: "network-proxy-v2",
+        allow_sync_access: list(
+          x["allow-sync-access"].map((x) => str(x, 255)),
+          255
+        ),
+      };
+    }
     default:
       throw unreachable(x);
   }
@@ -144,4 +153,11 @@ function str(x: unknown, size: number = Infinity): string {
     throw new Error(`String is too long (maximum: ${size})`);
   }
   return x;
+}
+
+function list<A>(xs: A[], size: number) {
+  if (xs.length > size) {
+    throw new Error(`List is too long (maximum: ${size})`);
+  }
+  return xs;
 }

--- a/packages/kate-core/source/kernel/process/runtimes.ts
+++ b/packages/kate-core/source/kernel/process/runtimes.ts
@@ -13,6 +13,7 @@ import { sandbox_html } from "./sandbox-html";
 export type RuntimeEnvConfig = {
   console: VirtualConsole;
   cart: Cart.CartMeta;
+  file_paths: string[];
   filesystem: IFileSystem;
   local_storage: unknown;
 };

--- a/packages/kate-core/source/kernel/process/sandbox-html.ts
+++ b/packages/kate-core/source/kernel/process/sandbox-html.ts
@@ -6,7 +6,7 @@
 
 import { bridges } from "../../bridges";
 import * as Cart from "../../cart";
-import { make_id, unreachable, file_to_dataurl, Pathname } from "../../utils";
+import { make_id, unreachable, file_to_dataurl, Pathname, GlobPattern } from "../../utils";
 import { RuntimeEnvConfig } from "./runtimes";
 import { KateButton } from "./../input";
 
@@ -15,7 +15,7 @@ type RuntimeEnv = RuntimeEnvConfig & { secret: string; trace: boolean };
 export async function sandbox_html(html: string, context: RuntimeEnv) {
   const dom = new DOMParser().parseFromString(html, "text/html");
   const preamble = add_preamble(dom, context);
-  add_bridges(preamble, dom, context);
+  await add_bridges(preamble, dom, context);
   await inline_all_scripts(dom, context);
   await inline_all_links(dom, context);
   await load_all_media(dom, context);
@@ -109,18 +109,18 @@ function add_preamble(dom: Document, context: RuntimeEnv) {
   return script;
 }
 
-function add_bridges(reference: Element, dom: Document, context: RuntimeEnv) {
+async function add_bridges(reference: Element, dom: Document, context: RuntimeEnv) {
   for (const bridge of context.cart.runtime.bridges) {
-    apply_bridge(bridge, reference, dom, context);
+    await apply_bridge(bridge, reference, dom, context);
   }
 }
 
-function apply_bridge(
+async function apply_bridge(
   bridge: Cart.Bridge,
   reference: Element,
   dom: Document,
   context: RuntimeEnv
-): void {
+): Promise<void> {
   const wrap = (source: string) => {
     return `void function(exports) {
       "use strict";
@@ -142,6 +142,21 @@ function apply_bridge(
   switch (bridge.type) {
     case "network-proxy": {
       append_proxy(bridges["standard-network.js"]);
+      break;
+    }
+
+    case "network-proxy-v2": {
+      const code = bridges["standard-network.js"];
+      const files = files_matching(context.file_paths, bridge.allow_sync_access);
+      const data = await Promise.all(
+        files.map((x) => ({ path: x, data: get_text_file(x, context) }))
+      );
+      const sync_access = JSON.stringify(Object.fromEntries(data.map((x) => [x.path, x.data])));
+      const full_source = `
+        const SYNC_ACCESS = ${sync_access};
+        ${code};
+      `;
+      append_proxy(full_source);
       break;
     }
 
@@ -380,4 +395,9 @@ function is_non_local(url: string) {
   } catch (_) {
     return false;
   }
+}
+
+function files_matching(files: string[], patterns: string[]) {
+  const globs = patterns.map((x) => GlobPattern.from_pattern(x));
+  return files.filter((x) => globs.some((g) => g.test(x)));
 }

--- a/packages/kate-core/source/kernel/process/sandbox-html.ts
+++ b/packages/kate-core/source/kernel/process/sandbox-html.ts
@@ -149,7 +149,7 @@ async function apply_bridge(
       const code = bridges["standard-network.js"];
       const files = files_matching(context.file_paths, bridge.allow_sync_access);
       const data = await Promise.all(
-        files.map((x) => ({ path: x, data: get_text_file(x, context) }))
+        files.map(async (x) => ({ path: x, data: await get_data_url(x, context) }))
       );
       const sync_access = JSON.stringify(Object.fromEntries(data.map((x) => [x.path, x.data])));
       const full_source = `

--- a/packages/kate-core/source/kernel/process/sandbox-html.ts
+++ b/packages/kate-core/source/kernel/process/sandbox-html.ts
@@ -67,7 +67,6 @@ async function load_all_media(dom: Document, context: RuntimeEnv) {
 
 function add_preamble(dom: Document, context: RuntimeEnv) {
   const script = dom.createElement("script");
-  const user_agent = "Kate";
   const id = `preamble_${make_id()}`;
   script.id = id;
   script.textContent = `
@@ -79,12 +78,6 @@ function add_preamble(dom: Document, context: RuntimeEnv) {
     script = null;
 
     ${bridges["kate-api.js"]};
-
-    Object.defineProperty(navigator, "userAgent", {
-      value: ${JSON.stringify(user_agent)},
-      enumerable: true,
-      configurable: true
-    });
   }();
   `;
   dom.head.insertBefore(script, dom.head.firstChild);

--- a/packages/kate-core/source/os/apis/processes.ts
+++ b/packages/kate-core/source/os/apis/processes.ts
@@ -52,6 +52,7 @@ export class KateProcesses {
       console: this.os.kernel.console,
       cart: cart,
       local_storage: storage,
+      file_paths: cart.files.map((x) => x.path),
       filesystem: {
         read: async (path) => {
           const node = file_map.get(path);
@@ -134,6 +135,7 @@ export class KateProcesses {
         console: this.os.kernel.console,
         cart: cart,
         local_storage: storage,
+        file_paths: cart.files.map((x) => x.path),
         filesystem: {
           read: async (path) => {
             const file_id = file_map.get(path);

--- a/packages/kate-core/source/utils.ts
+++ b/packages/kate-core/source/utils.ts
@@ -23,6 +23,7 @@ export * from "../../util/build/time";
 export * from "../../util/build/serialise";
 export * from "../../util/build/semver";
 export * from "../../util/build/binary";
+export * from "../../util/build/glob-match";
 
 export function lock<T>(name: string, fn: () => Promise<T>): Promise<T> {
   return navigator.locks.request(name, fn);

--- a/packages/kate-tools/source/kart-show.ts
+++ b/packages/kate-tools/source/kart-show.ts
@@ -191,6 +191,12 @@ function bridge(x: Cart.Bridge) {
       return `network-proxy`;
     }
 
+    case t.$Tags.Network_proxy_v2: {
+      return `network-proxy-v2 {
+  allow_sync_access: ${JSON.stringify(x["allow-sync-access"])}
+}`;
+    }
+
     case t.$Tags.Pointer_input_proxy: {
       return `pointer-input-proxy {
   CSS selector: ${JSON.stringify(x.selector)}

--- a/packages/kate-tools/source/kart.ts
+++ b/packages/kate-tools/source/kart.ts
@@ -225,6 +225,17 @@ const recipe = T.tagged_choice<Recipe, Recipe["type"]>("type", {
     hide_cursor: T.optional(false, T.bool),
     open_urls_reason: T.optional(null, T.short_str(255)),
   }),
+  godot: T.spec({
+    type: T.constant("godot" as const),
+    version: T.constant("3" as const),
+    pointer_support: T.optional(true, T.bool),
+    hide_cursor: T.optional(false, T.bool),
+  }),
+  "rpg-maker-mv": T.spec({
+    type: T.constant("rpg-maker-mv" as const),
+    pointer_support: T.optional(true, T.bool),
+    hide_cursor: T.optional(false, T.bool),
+  }),
 });
 
 const platform_web = T.spec({
@@ -398,7 +409,9 @@ type Recipe =
       open_urls_reason: string | null;
       renpy_version: string;
     }
-  | { type: "bitsy" };
+  | { type: "bitsy" }
+  | { type: "godot"; version: "3"; pointer_support: boolean; hide_cursor: boolean }
+  | { type: "rpg-maker-mv"; pointer_support: boolean; hide_cursor: boolean };
 
 const mime_table = Object.assign(Object.create(null), {
   // Text/code
@@ -1073,6 +1086,73 @@ function apply_recipe(json: ReturnType<typeof config>): ReturnType<typeof config
         },
       };
     }
+
+    case "godot": {
+      return {
+        ...json,
+        files: ["**/*.html", "**/*.png", "**/*.js", "**/*.pck", "**/*.wasm"],
+        platform: {
+          recipe,
+          type: "web-archive",
+          html: json.platform.html,
+          bridges: select_bridges([
+            { type: "network-proxy", sync_access: ["*.js"] },
+            { type: "keyboard-input-proxy-v2", mapping: "defaults", selector: "#canvas" },
+            ...(recipe.pointer_support
+              ? [
+                  {
+                    type: "pointer-input-proxy" as const,
+                    selector: "#canvas",
+                    hide_cursor: recipe.hide_cursor,
+                  },
+                ]
+              : []),
+            { type: "capture-canvas", selector: "#canvas" },
+            { type: "preserve-webgl-render" },
+            ...json.platform.bridges,
+          ]),
+        },
+      };
+    }
+
+    case "rpg-maker-mv": {
+      return {
+        ...json,
+        files: [
+          "**/*.html",
+          "**/*.json",
+          "**/*.ogg",
+          "**/*.css",
+          "**/*.ttf",
+          "**/*.png",
+          "**/*.txt",
+          "**/*.js",
+        ],
+        platform: {
+          recipe,
+          type: "web-archive",
+          html: json.platform.html,
+          bridges: select_bridges([
+            { type: "network-proxy", sync_access: ["js/plugins/*.js", "img/tilesets/*.png"] },
+            { type: "keyboard-input-proxy-v2", mapping: "defaults", selector: "document" },
+            ...(recipe.pointer_support
+              ? [
+                  {
+                    type: "pointer-input-proxy" as const,
+                    selector: "#GameCanvas",
+                    hide_cursor: recipe.hide_cursor,
+                  },
+                ]
+              : []),
+            { type: "capture-canvas", selector: "#GameCanvas" },
+            { type: "preserve-webgl-render" },
+            { type: "local-storage-proxy" },
+            ...json.platform.bridges,
+          ]),
+        },
+      };
+    }
+
     default:
       throw unreachable(recipe, "Recipe");
   }

--- a/packages/kate-tools/source/kart.ts
+++ b/packages/kate-tools/source/kart.ts
@@ -160,6 +160,7 @@ const meta = T.spec({
 const bridges = T.tagged_choice<Bridge, Bridge["type"]>("type", {
   "network-proxy": T.spec({
     type: T.constant("network-proxy" as const),
+    sync_access: T.list_of(T.short_str(255)),
   }),
   "local-storage-proxy": T.spec({
     type: T.constant("local-storage-proxy" as const),
@@ -173,7 +174,7 @@ const bridges = T.tagged_choice<Bridge, Bridge["type"]>("type", {
     ),
   }),
   "keyboard-input-proxy-v2": T.spec({
-    type: T.constant("input-proxy" as const),
+    type: T.constant("keyboard-input-proxy-v2" as const),
     mapping: T.or3(
       T.constant("defaults" as const),
       T.constant("kate" as const),
@@ -372,7 +373,7 @@ type ContextualCapability =
   | { type: "store-temporary-files"; max_size_mb: number; optional: boolean };
 
 type Bridge =
-  | { type: "network-proxy" }
+  | { type: "network-proxy"; sync_access?: string[] }
   | { type: "local-storage-proxy" }
   | { type: "input-proxy"; mapping: KeyMapping }
   | {
@@ -798,7 +799,11 @@ function make_capability(json: Capability) {
 function make_bridge(x: Bridge): Cart.Bridge[] {
   switch (x.type) {
     case "network-proxy": {
-      return [Cart.Bridge.Network_proxy({})];
+      return [
+        Cart.Bridge.Network_proxy_v2({
+          "allow-sync-access": x.sync_access ?? [],
+        }),
+      ];
     }
 
     case "local-storage-proxy": {

--- a/packages/schema/schemas/kart-v6.ljt
+++ b/packages/schema/schemas/kart-v6.ljt
@@ -222,6 +222,10 @@ union Bridge {
     field mapping: Virtual-key -> Keyboard-key;
     field selector: Keyboard-input-selector;
   }
+
+  type Network-proxy-v2 {
+    field allow-sync-access: Text[];
+  }
 }
 
 union Virtual-key {

--- a/packages/schema/source/generated/kart-v6.json
+++ b/packages/schema/source/generated/kart-v6.json
@@ -964,6 +964,20 @@
                   }
                 }
               ]
+            },
+            {
+              "name": "Network-proxy-v2",
+              "fields": [
+                {
+                  "name": "allow-sync-access",
+                  "type": {
+                    "op": "array",
+                    "items": {
+                      "op": "text"
+                    }
+                  }
+                }
+              ]
             }
           ]
         }

--- a/packages/schema/source/generated/kart-v6.ts
+++ b/packages/schema/source/generated/kart-v6.ts
@@ -1375,7 +1375,7 @@ export namespace Accessibility_provision {
 
 
 
-export type Bridge = Bridge.Network_proxy | Bridge.Local_storage_proxy | Bridge.Input_proxy | Bridge.Preserve_WebGL_render | Bridge.Capture_canvas | Bridge.Pointer_input_proxy | Bridge.IndexedDB_proxy | Bridge.Renpy_web_tweaks | Bridge.External_URL_handler | Bridge.Keyboard_input_proxy_v2;
+export type Bridge = Bridge.Network_proxy | Bridge.Local_storage_proxy | Bridge.Input_proxy | Bridge.Preserve_WebGL_render | Bridge.Capture_canvas | Bridge.Pointer_input_proxy | Bridge.IndexedDB_proxy | Bridge.Renpy_web_tweaks | Bridge.External_URL_handler | Bridge.Keyboard_input_proxy_v2 | Bridge.Network_proxy_v2;
 
 export namespace Bridge {
  export const tag = 22;
@@ -1390,7 +1390,8 @@ export namespace Bridge {
     IndexedDB_proxy = 6,
     Renpy_web_tweaks = 7,
     External_URL_handler = 8,
-    Keyboard_input_proxy_v2 = 9
+    Keyboard_input_proxy_v2 = 9,
+    Network_proxy_v2 = 10
  }
 
  
@@ -1612,6 +1613,28 @@ export namespace Bridge {
    readonly '@variant-name': 'Keyboard-input-proxy-v2';
    readonly 'mapping': Map<Virtual_key, Keyboard_key>
     readonly 'selector': Keyboard_input_selector
+ }
+
+
+  
+ export function Network_proxy_v2(x: {readonly 'allow-sync-access': (string)[]}): Bridge {
+   return {
+     '@name': 'Bridge',
+     '@tag': 22,
+     '@version': 0,
+     '@variant': $Tags.Network_proxy_v2,
+     '@variant-name': 'Network-proxy-v2',
+     ...x
+   }
+ }
+
+ export interface Network_proxy_v2 {
+   readonly '@name': 'Bridge';
+   readonly '@tag': 22;
+   readonly '@version': 0;
+   readonly '@variant': $Tags.Network_proxy_v2;
+   readonly '@variant-name': 'Network-proxy-v2';
+   readonly 'allow-sync-access': (string)[]
  }
 
 }


### PR DESCRIPTION
In general, cartridge files live only in the kernel side, and cartridge processes must use an asynchronous RPC call to read them. This generally works for games made exclusively for Kate, however existing engines have varied needs of reading data "synchronously" (at least from the perspective of the game's code), so we need to support that as well.

This patch adds a way of pre-loading certain assets at the time the cartridge sandbox is being built, such that all reads of these assets from the cartridge's process appear to be synchronous (since they're moved to the cartridge's process at the time the sandbox is built). This in turn lets us support games written in RPG Maker MV and Godot 3 and 4 with no changes required on the game's code. The environment just fulfils all of the game's code expectations instead.

Note that Godot 4 games are not yet *enabled* in Kate due to the security vulnerability described in https://github.com/orgs/qteatime/discussions/1 --- cartridge processes need to be fully isolated before Godot 4 games can be enabled, as their processing requirements make it possible for cartridges to exploit Spectre vulnerabilities to read privileged information from the Kate kernel process, at least in theory.