### PR TITLE
Add install prompts before cartridge installation

### DIFF
--- a/packages/kate-core/RELEASE.txt
+++ b/packages/kate-core/RELEASE.txt
@@ -1,5 +1,5 @@
 =======================================================================
-Kate v0.25  (April 2024)
+Kate v0.25  (Spring 2024)
 =======================================================================
 
 The v0.25 is the Spring experimental release of Kate. This release
@@ -148,3 +148,6 @@ Minor fixes and improvements
 
 * Added a "process log" which shows messages output by each process to
   standard outputs (#43);
+
+* Added a confirmation dialog before installing cartridges to notify players
+  of the risks they're taking (#45);

--- a/packages/kate-core/source/capabilities/index.ts
+++ b/packages/kate-core/source/capabilities/index.ts
@@ -7,3 +7,4 @@
 export * from "./definitions";
 export * from "./serialisation";
 export * from "./risk";
+export * from "./summarise";

--- a/packages/kate-core/source/capabilities/summarise.ts
+++ b/packages/kate-core/source/capabilities/summarise.ts
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type { CartMeta } from "../cart";
+import type { AnyCapability, CategorySummary } from "./definitions";
+import { RiskCategory, compare_risk } from "./risk";
+import { grants_from_cartridge } from "./serialisation";
+
+type RiskSummary = {
+  acceptable: CategorySummary[];
+  to_review: AnyCapability[];
+};
+
+export function summarise_from_cartridge(cart: CartMeta, max_risk: RiskCategory): RiskSummary {
+  const categories = new Map<string, AnyCapability>();
+  const grants0 = grants_from_cartridge(cart).filter((x) => !x.is_contextual);
+  const summarised = grants0.filter((x) => compare_risk(x.base_risk, max_risk) < 0);
+  const to_review = grants0.filter((x) => compare_risk(x.base_risk, max_risk) >= 0);
+
+  for (const grant of summarised) {
+    const grant_summary = grant.summary!;
+
+    const old = categories.get(grant_summary.category);
+    if (old) {
+      categories.set(grant_summary.category, grant_summary.combine(old));
+    } else {
+      categories.set(grant_summary.category, grant);
+    }
+  }
+
+  return {
+    acceptable: [...categories.values()].map((x) => x.summary!),
+    to_review: to_review,
+  };
+}

--- a/packages/kate-core/source/cart/cart-type.ts
+++ b/packages/kate-core/source/cart/cart-type.ts
@@ -177,6 +177,14 @@ export type CartMeta = {
   metadata: Metadata;
   runtime: Runtime;
   security: Security;
+  signatures: Signature[];
+};
+
+export type Signature = {
+  signed_by: string;
+  key_id: string;
+  signature: Uint8Array;
+  verified: boolean;
 };
 
 export type DataCart = CartMeta & {

--- a/packages/kate-core/source/cart/parser-utils.ts
+++ b/packages/kate-core/source/cart/parser-utils.ts
@@ -14,6 +14,16 @@ export function str(x: unknown, size: number = Infinity): string {
   return x;
 }
 
+export function bytes(x: unknown, size: number = Infinity): Uint8Array {
+  if (!(x instanceof Uint8Array)) {
+    throw new Error(`Expected bytes`);
+  }
+  if (x.length > size) {
+    throw new Error(`Too many bytes (maximum: ${size})`);
+  }
+  return x;
+}
+
 export function regex(name: string, re: RegExp) {
   return (x: unknown) => {
     if (!re.test(str(x))) {

--- a/packages/kate-core/source/cart/parser.ts
+++ b/packages/kate-core/source/cart/parser.ts
@@ -20,6 +20,7 @@ export type Parser<T> = {
   minimum_version(header: T): SemVer;
   parse_header(x: Blob): Promise<T>;
   parse_meta(x: Blob, header: T): Promise<DataCart>;
+  raw_meta(x: Blob, header: T): Promise<Uint8Array>;
   parse_files(x: Blob, header: T, metadata: DataCart): AsyncGenerator<YieldFile, void, void>;
 };
 
@@ -29,6 +30,7 @@ const parsers: Parser<unknown>[] = [
     minimum_version: v6.minimum_version,
     parse_header: v6.decode_header,
     parse_meta: v6.decode_metadata,
+    raw_meta: v6.read_raw_metadata,
     parse_files: v6.decode_files,
   },
 ];

--- a/packages/kate-core/source/cart/parser.ts
+++ b/packages/kate-core/source/cart/parser.ts
@@ -22,6 +22,12 @@ export type Parser<T> = {
   parse_meta(x: Blob, header: T): Promise<DataCart>;
   raw_meta(x: Blob, header: T): Promise<Uint8Array>;
   parse_files(x: Blob, header: T, metadata: DataCart): AsyncGenerator<YieldFile, void, void>;
+  read_file_with_path(
+    x: Blob,
+    metadata: DataCart,
+    path: string,
+    max_size_bytes: number | null
+  ): Promise<null | DataFile>;
 };
 
 const parsers: Parser<unknown>[] = [
@@ -32,6 +38,7 @@ const parsers: Parser<unknown>[] = [
     parse_meta: v6.decode_metadata,
     raw_meta: v6.read_raw_metadata,
     parse_files: v6.decode_files,
+    read_file_with_path: v6.read_file_with_path,
   },
 ];
 

--- a/packages/kate-core/source/data/cartridge.ts
+++ b/packages/kate-core/source/data/cartridge.ts
@@ -27,6 +27,7 @@ export type CartMeta_v3 = {
   bucket_key: PersistentKey | null; // null for archived cartridges
   installed_at: Date;
   updated_at: Date;
+  signatures: Cart.Signature[];
   status: CartridgeStatus;
 };
 export const cart_meta_v3 = kate.table1<CartMeta_v3, "id">({
@@ -108,6 +109,7 @@ export class CartStore {
       installed_at: old_meta?.installed_at ?? now,
       updated_at: now,
       status: "active",
+      signatures: cart.signatures,
     });
   }
 

--- a/packages/kate-core/source/data/db.ts
+++ b/packages/kate-core/source/data/db.ts
@@ -6,4 +6,4 @@
 
 import * as Db from "../db-schema";
 
-export const kate = new Db.DatabaseSchema("kate", 21);
+export const kate = new Db.DatabaseSchema("kate", 22);

--- a/packages/kate-core/source/data/migrations/index.ts
+++ b/packages/kate-core/source/data/migrations/index.ts
@@ -8,3 +8,4 @@ import "./deprecated";
 import "./v15";
 import "./v16";
 import "./v17";
+import "./v22";

--- a/packages/kate-core/source/data/migrations/v15.ts
+++ b/packages/kate-core/source/data/migrations/v15.ts
@@ -77,6 +77,7 @@ kate.data_migration({
           const { key, nodes } = buckets.get(cartridge.id)!;
           await cv3.add({
             ...cartridge,
+            signatures: [],
             minimum_kate_version: { major: 0, minor: 24, patch: 2 },
             bucket_key: key,
             files: cartridge.files.map((x) => {
@@ -100,6 +101,7 @@ kate.data_migration({
             minimum_kate_version: { major: 0, minor: 24, patch: 2 },
             bucket_key: null,
             files: [],
+            signatures: [],
           });
         }
       }

--- a/packages/kate-core/source/data/migrations/v22.ts
+++ b/packages/kate-core/source/data/migrations/v22.ts
@@ -1,0 +1,28 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { cart_meta_v3 } from "../cartridge";
+import { kate } from "../db";
+
+kate.data_migration({
+  id: "v22/signature",
+  description: "Migrating cartridges to a new format",
+  since: 22,
+  async process(db, os) {
+    await db.transaction([cart_meta_v3], "readwrite", async (txn) => {
+      const tcarts = txn.get_table1(cart_meta_v3);
+      for (const cart of await tcarts.get_all()) {
+        if (Array.isArray(cart.signatures)) {
+          console.debug(`[kate:db] Skipping ${cart.id} (already migrated)`);
+          continue;
+        }
+
+        console.debug(`[kate:db] Migrating ${cart.id}`);
+        await tcarts.put({ ...cart, signatures: [] });
+      }
+    });
+  },
+});

--- a/packages/kate-core/source/os/apis/cart-manager.ts
+++ b/packages/kate-core/source/os/apis/cart-manager.ts
@@ -8,7 +8,9 @@ import * as Cart from "../../cart";
 import * as Capability from "../../capabilities";
 import type { KateOS } from "../os";
 import * as Db from "../../data";
+import * as UI from "../ui";
 import {
+  SemVer,
   from_bytes,
   gb,
   make_thumbnail_from_bytes,
@@ -169,6 +171,96 @@ export class CartManager {
     }
   }
 
+  async ask_install_confirmation(cart: Cart.DataCart, old_meta: Db.CartMeta_v3 | null) {
+    const [publisher, id] = cart.id.split("/");
+
+    const risk_summary = Capability.summarise_from_cartridge(
+      cart,
+      this.os.settings.get("security").prompt_for
+    );
+
+    const optional = new Map(
+      cart.security.passive_capabilities.map((x) => [
+        x.capability.type as Db.CapabilityType,
+        x.optional,
+      ])
+    );
+
+    const additional_risk =
+      risk_summary.to_review.length === 0
+        ? []
+        : [`${risk_summary.to_review.length} high-risk permissions`];
+    const acceptable_risk =
+      risk_summary.acceptable.length === 0 ? [] : risk_summary.acceptable.map((x) => x.description);
+    const risks = [...acceptable_risk, ...additional_risk];
+    const summary_msg =
+      risks.length === 0
+        ? `no passive permissions`
+        : risks.length === 1
+        ? `access to ${risks[0]}`
+        : `access to ${risks.slice(0, -1).join(", ")}, and ${risks.at(-1)}`;
+
+    const verified_status = UI.with_class("kate-unverified", UI.fa_icon("triangle-exclamation"));
+    const verified_class = `kate-unverified`;
+
+    const content = UI.klass("kate-ui-install-confirmation", [
+      UI.grid({
+        layout: [
+          ["thumb", "meta"],
+          ["thumb", "cap"],
+        ],
+        column_sizes: ["100px", "1fr"],
+        row_sizes: ["min-content", "1fr"],
+        gap: "1rem",
+        content: {
+          thumb: UI.klass("kate-ui-cartridge-thumbnail", [UI.no_thumbnail()]),
+          meta: UI.klass("kate-ui-cartridge-info", [
+            UI.klass("kate-ui-cartridge-info-title", [cart.metadata.presentation.title]),
+            UI.klass("kate-ui-cartridge-info-id", [id, ` v${cart.version}`]),
+            UI.klass(`kate-ui-cartridge-info-publisher ${verified_class}`, [
+              UI.fa_icon("user"),
+              UI.klass("kate-ui-cartridge-info-publisher-status", [publisher, verified_status]),
+            ]),
+          ]),
+          cap: UI.vbox(0.5, [
+            UI.meta_text([`This cartridge requires ${summary_msg}.`]),
+            UI.with_style(
+              { padding: "0.5rem" },
+              UI.scroll([
+                ...risk_summary.to_review.map((x) => {
+                  const is_optional = optional.get(x.type) ?? true;
+                  return UI.toggle_cell(this.os, {
+                    title: x.title,
+                    description: "",
+                    value: !is_optional,
+                    readonly: !is_optional,
+                  });
+                }),
+              ])
+            ),
+          ]),
+        },
+      }),
+    ]);
+    const prev_version = old_meta?.version ? SemVer.try_parse(old_meta.version, null) : null;
+    const new_version = SemVer.try_parse(cart.version, null)!;
+    const cancel_button = old_meta == null ? "Cancel" : "Keep current";
+    const install_button =
+      prev_version == null
+        ? "Install"
+        : new_version.gt(prev_version)
+        ? `Upgrade from ${old_meta!.version}`
+        : new_version.lt(prev_version)
+        ? `Downgrade from ${old_meta!.version}`
+        : "Re-install";
+    return this.os.dialog.confirm("kate:cart-manager", {
+      title: `${install_button} cartridge`,
+      message: content,
+      ok: install_button,
+      cancel: cancel_button,
+    });
+  }
+
   async install(cart: Cart.DataCart, files: AsyncIterable<{ index: number; data: Uint8Array }>) {
     if (this.os.kernel.console.options.mode === "single") {
       throw new Error(`Cartridge installation is not available in single mode.`);
@@ -178,30 +270,27 @@ export class CartManager {
     if (old_meta != null) {
       const version = cart.version;
       const title = cart.metadata.presentation.title;
-      const old_title = old_meta.metadata.presentation.title;
       const old_version = old_meta.version;
-      if (old_meta.status === "active") {
-        if (old_version === version && !this.os.settings.get("developer").allow_version_overwrite) {
-          await this.os.notifications.push_transient(
-            "kate:cart-manager",
-            `Cartridge not installed`,
-            `${title} (${cart.id}) is already installed at version v${old_version}`
-          );
-          return false;
-        } else {
-          const should_update = await this.os.dialog.confirm("kate:installer", {
-            title: `Update ${old_title}?`,
-            message: `A cartridge already exists for ${cart.id} (${old_title} v${old_version}).
-                      Update it to ${title} v${version}?`,
-            ok: "Update",
-            cancel: "Keep old version",
-            dangerous: true,
-          });
-          if (!should_update) {
-            return false;
-          }
-        }
+      if (
+        old_meta.status === "active" &&
+        old_version === version &&
+        !this.os.settings.get("developer").allow_version_overwrite
+      ) {
+        await this.os.notifications.push_transient(
+          "kate:cart-manager",
+          `Cartridge not installed`,
+          `${title} (${cart.id}) is already installed at version v${old_version}`
+        );
+        return false;
       }
+    }
+
+    const should_install = await this.ask_install_confirmation(
+      cart,
+      old_meta?.status === "active" ? old_meta : null
+    );
+    if (!should_install) {
+      return;
     }
 
     const cart_partition = await this.os.file_store.get_partition("cartridge");

--- a/packages/kate-core/source/os/apis/cart-manager.ts
+++ b/packages/kate-core/source/os/apis/cart-manager.ts
@@ -209,8 +209,14 @@ export class CartManager {
         : `access to ${risks.slice(0, -1).join(", ")}, and ${risks.at(-1)}`;
 
     const verified_status = verified_publisher
-      ? UI.with_class("kate-verified", UI.fa_icon("circle-check"))
-      : UI.with_class("kate-unverified", UI.fa_icon("triangle-exclamation"));
+      ? UI.klass("kate-ui-verification-badge kate-verified", [
+          UI.fa_icon("circle-check"),
+          " verified",
+        ])
+      : UI.klass("kate-ui-verification-badge kate-unverified", [
+          UI.fa_icon("triangle-exclamation"),
+          " unverified",
+        ]);
     const verified_class = verified_publisher ? `kate-verified` : `kate-unverified`;
 
     const content = UI.klass("kate-ui-install-confirmation", [
@@ -223,13 +229,18 @@ export class CartManager {
         row_sizes: ["min-content", "1fr"],
         gap: "1rem",
         content: {
-          thumb: UI.klass("kate-ui-cartridge-thumbnail", [UI.no_thumbnail()]),
+          thumb: UI.klass("kate-ui-cartridge-thumbnail", [
+            UI.no_thumbnail(),
+            UI.release_type(cart.metadata.presentation.release_type),
+            UI.rating_icon(cart.metadata.classification.rating),
+          ]),
           meta: UI.klass("kate-ui-cartridge-info", [
             UI.klass("kate-ui-cartridge-info-title", [cart.metadata.presentation.title]),
             UI.klass("kate-ui-cartridge-info-id", [id, ` v${cart.version}`]),
             UI.klass(`kate-ui-cartridge-info-publisher ${verified_class}`, [
               UI.fa_icon("user"),
-              UI.klass("kate-ui-cartridge-info-publisher-status", [publisher, verified_status]),
+              UI.klass(`kate-ui-cartridge-info-publisher-status ${verified_class}`, [publisher]),
+              verified_status,
             ]),
           ]),
           cap: UI.vbox(0.5, [

--- a/packages/kate-core/source/os/apis/cart-manager.ts
+++ b/packages/kate-core/source/os/apis/cart-manager.ts
@@ -307,7 +307,7 @@ export class CartManager {
         ? `Downgrade from ${old_meta!.version}`
         : "Re-install";
     return this.os.dialog.confirm("kate:cart-manager", {
-      title: `${install_button} cartridge`,
+      title: `${install_button} cartridge?`,
       message: content,
       ok: install_button,
       cancel: cancel_button,

--- a/packages/kate-core/source/os/apps/home.ts
+++ b/packages/kate-core/source/os/apps/home.ts
@@ -41,22 +41,8 @@ export class SceneHome extends SimpleScene {
           x.thumbnail_dataurl
             ? h("img", { src: x.thumbnail_dataurl }, [])
             : UI.no_thumbnail(x.metadata.presentation.title),
-          h(
-            "div",
-            {
-              class: "kate-os-carts-release-type",
-              "data-release-type": x.metadata.presentation.release_type,
-            },
-            [pretty_release_type(x.metadata.presentation.release_type)]
-          ),
-          h(
-            "div",
-            {
-              class: "kate-os-carts-rating",
-              "data-rating": x.metadata.classification.rating,
-            },
-            [rating_icon(x.metadata.classification.rating)]
-          ),
+          UI.release_type(x.metadata.presentation.release_type),
+          UI.rating_icon(x.metadata.classification.rating),
         ]),
         h("div", { class: "kate-os-carts-title" }, [x.metadata.presentation.title]),
       ]),
@@ -231,41 +217,5 @@ export class SceneHome extends SimpleScene {
   async play(id: string) {
     await this.os.processes.run(id);
     await this.update_carts();
-  }
-}
-
-function pretty_release_type(x: ReleaseType) {
-  switch (x) {
-    case "beta":
-      return "Beta";
-    case "demo":
-      return "Demo";
-    case "early-access":
-      return "Dev.";
-    case "prototype":
-      return "PoC";
-    case "regular":
-      return "Full";
-    case "unofficial":
-      return "Unofficial";
-    default:
-      throw unreachable(x, "release type");
-  }
-}
-
-function rating_icon(x: ContentRating) {
-  switch (x) {
-    case "general":
-      return "G";
-    case "teen-and-up":
-      return "T";
-    case "mature":
-      return "M";
-    case "explicit":
-      return "E";
-    case "unknown":
-      return "—";
-    default:
-      throw unreachable(x, "content rating");
   }
 }

--- a/packages/kate-core/source/os/ui/widget.ts
+++ b/packages/kate-core/source/os/ui/widget.ts
@@ -8,7 +8,7 @@ import { capabilities } from "../..";
 import * as Cart from "../../cart";
 import type { DeveloperProfile } from "../../data";
 import type { KateButton } from "../../kernel";
-import { EventStream, Observable, load_image_from_bytes } from "../../utils";
+import { EventStream, Observable, load_image_from_bytes, unreachable } from "../../utils";
 import type { InteractionHandler } from "../apis";
 import type { KateOS } from "../os";
 
@@ -1250,6 +1250,28 @@ export function developer_profile_chip(profile: DeveloperProfile) {
   ]);
 }
 
+export function release_type(x: Cart.ReleaseType) {
+  return h(
+    "div",
+    {
+      class: "kate-os-carts-release-type",
+      "data-release-type": x,
+    },
+    [pretty_release_type(x)]
+  );
+}
+
+export function rating_icon(x: Cart.ContentRating) {
+  return h(
+    "div",
+    {
+      class: "kate-os-carts-rating",
+      "data-rating": x,
+    },
+    [pretty_rating_icon(x)]
+  );
+}
+
 export function grid(x: {
   layout: string[][];
   column_sizes?: string[];
@@ -1290,4 +1312,40 @@ export function with_style(
 export function with_class(klass: string, child: HTMLElement) {
   child.className += ` ${klass}`;
   return child;
+}
+
+function pretty_release_type(x: Cart.ReleaseType) {
+  switch (x) {
+    case "beta":
+      return "Beta";
+    case "demo":
+      return "Demo";
+    case "early-access":
+      return "Dev.";
+    case "prototype":
+      return "PoC";
+    case "regular":
+      return "Full";
+    case "unofficial":
+      return "Unofficial";
+    default:
+      throw unreachable(x, "release type");
+  }
+}
+
+function pretty_rating_icon(x: Cart.ContentRating) {
+  switch (x) {
+    case "general":
+      return "G";
+    case "teen-and-up":
+      return "T";
+    case "mature":
+      return "M";
+    case "explicit":
+      return "E";
+    case "unknown":
+      return "—";
+    default:
+      throw unreachable(x, "content rating");
+  }
 }

--- a/packages/kate-core/source/utils.ts
+++ b/packages/kate-core/source/utils.ts
@@ -30,4 +30,10 @@ export function lock<T>(name: string, fn: () => Promise<T>): Promise<T> {
   return navigator.locks.request(name, fn);
 }
 
+export function mut<T extends { [key: string]: any }>(
+  x: T
+): { -readonly [key in keyof T]: T[key] } {
+  return x as any;
+}
+
 export type OptionalRec<T> = T extends {} ? { [k in keyof T]?: OptionalRec<T[k]> } : T;

--- a/packages/util/source/semver.ts
+++ b/packages/util/source/semver.ts
@@ -7,7 +7,7 @@ export class SemVer {
   ) {}
 
   static try_parse(version: string, default_build: string | null): SemVer | null {
-    const re = /^(\d+)\.(\d+)\.(\d+)(?:\-(.*))?/;
+    const re = /^(\d+)\.(\d+)(?:\.(\d+))?(?:\-(.*))?/;
     const matches = version.match(re);
     if (matches == null) {
       return null;
@@ -16,7 +16,7 @@ export class SemVer {
       return new SemVer(
         Number(major),
         Number(minor),
-        Number(patch),
+        Number(patch ?? "0"),
         build?.trim() || default_build
       );
     }
@@ -28,22 +28,22 @@ export class SemVer {
 
   gt(that: SemVer) {
     return (
-      that.major > this.major ||
-      (that.major === this.major && that.minor > this.minor) ||
-      (that.major === this.major && that.minor === this.minor && that.patch > this.patch)
+      this.major > that.major ||
+      (this.major === that.major && this.minor > that.minor) ||
+      (this.major === that.major && this.minor === that.minor && this.patch > that.patch)
     );
   }
 
   gte(that: SemVer) {
-    return that.gt(this) || that.equals(this);
+    return this.gt(that) || this.equals(that);
   }
 
   lt(that: SemVer) {
-    return !that.gt(this) && !that.equals(this);
+    return !this.gt(that) && !this.equals(that);
   }
 
   lte(that: SemVer) {
-    return !that.gt(this);
+    return !this.gt(that);
   }
 
   toString() {

--- a/www/css/os/hud/index.css
+++ b/www/css/os/hud/index.css
@@ -12,3 +12,4 @@
 @import url("./status-bar.css");
 @import url("./dialog-progress.css");
 @import url("./base-dialog.css");
+@import url("./install-dialog.css");

--- a/www/css/os/hud/install-dialog.css
+++ b/www/css/os/hud/install-dialog.css
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+.kate-ui-install-confirmation .kate-ui-cartridge-thumbnail {
+  border: 1px solid var(--color-border);
+  padding: 1px;
+}
+
+.kate-ui-cartridge-info {
+  font-size: 0.9rem;
+}
+
+.kate-ui-cartridge-info-title {
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.kate-ui-cartridge-info-id {
+  font-family: var(--font-family-mono);
+  font-size: 0.8rem;
+}
+
+.kate-ui-cartridge-info-publisher {
+  font-size: 0.8rem;
+  font-family: var(--font-family-mono);
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.kate-unverified {
+  color: var(--red);
+}
+
+.kate-ui-cartridge-info-publisher-status i {
+  padding: 0 0.25rem;
+}

--- a/www/css/os/hud/install-dialog.css
+++ b/www/css/os/hud/install-dialog.css
@@ -7,6 +7,7 @@
 .kate-ui-install-confirmation .kate-ui-cartridge-thumbnail {
   border: 1px solid var(--color-border);
   padding: 1px;
+  position: relative;
 }
 
 .kate-ui-cartridge-info {
@@ -30,16 +31,26 @@
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
+  color: var(--badge-color);
+}
+
+.kate-ui-verification-badge {
+  display: inline-block;
+  border: 1px solid var(--badge-color);
+  color: var(--badge-color);
+  border-radius: 1em;
+  padding: 0.2rem 1rem;
+  font-family: var(--font-family-sans);
+  display: flex;
+  flex-direction: row;
+  gap: 0.2rem;
+  align-items: baseline;
 }
 
 .kate-unverified {
-  color: var(--red);
+  --badge-color: var(--red);
 }
 
 .kate-verified {
-  color: var(--green);
-}
-
-.kate-ui-cartridge-info-publisher-status i {
-  padding: 0 0.25rem;
+  --badge-color: var(--green);
 }

--- a/www/css/os/hud/install-dialog.css
+++ b/www/css/os/hud/install-dialog.css
@@ -54,3 +54,8 @@
 .kate-verified {
   --badge-color: var(--green);
 }
+
+.kate-ui-cartridge-thumbnail img {
+  width: 100%;
+  display: block;
+}

--- a/www/css/os/hud/install-dialog.css
+++ b/www/css/os/hud/install-dialog.css
@@ -36,6 +36,10 @@
   color: var(--red);
 }
 
+.kate-verified {
+  color: var(--green);
+}
+
 .kate-ui-cartridge-info-publisher-status i {
   padding: 0 0.25rem;
 }

--- a/www/css/os/ui.css
+++ b/www/css/os/ui.css
@@ -625,3 +625,7 @@
   word-break: break-all;
   font-size: 0.8em;
 }
+
+.kate-ui-grid {
+  display: grid;
+}


### PR DESCRIPTION
This patch adds a small install prompt before the actual cartridge installation. The prompt provides information about what cartridge is being installed, whether the cartridge signature has been verified, and any higher-risk capabilities that the cartridge requires to work.

There's still some work that needs to happen on both the capability-granting side and on showing what has been verified about the cartridge. Those will have to be done in a separate patch as it requires a bit more of deliberation; the design in this case is straightforward enough to not have an accompanying design document, but signature verification and communication will need one eventually.

![Screenshot 2024-05-06 181621](https://github.com/qteatime/kate/assets/154556730/f1468d47-8b49-4f8e-9ae0-e61086b0add8)
